### PR TITLE
changes to files collectors

### DIFF
--- a/collectors/logs
+++ b/collectors/logs
@@ -14,51 +14,8 @@
 
 # logs collector
 
-FIND_MAXDEPTH_PARAMETER=""
-if [ "$LOGS_MAX_DEPTH" -gt 0 ]; then
-    FIND_MAXDEPTH_PARAMETER="-maxdepth $LOGS_MAX_DEPTH"
-fi
-
-FIND_SIZE_PARAMETER=""
-if [ "$LOGS_MAX_FILE_SIZE" -gt 0 ]; then
-    FIND_SIZE_PARAMETER="-size -${LOGS_MAX_FILE_SIZE}c"
-fi
-
-FIND_ATIME_PARAMETER=""
-FIND_MTIME_PARAMETER=""
-FIND_CTIME_PARAMETER=""
-if [ "$DATE_RANGE_T1" ]; then
-    $DATE_RANGE_ATIME && FIND_ATIME_PARAMETER="-atime $DATE_RANGE_T1"
-    $DATE_RANGE_MTIME && FIND_MTIME_PARAMETER="-mtime $DATE_RANGE_T1"
-    $DATE_RANGE_CTIME && FIND_CTIME_PARAMETER="-ctime $DATE_RANGE_T1"
-fi
-if [ "$DATE_RANGE_T2" ]; then
-    $DATE_RANGE_ATIME && FIND_ATIME_PARAMETER="$FIND_ATIME_PARAMETER -atime $DATE_RANGE_T2"
-    $DATE_RANGE_MTIME && FIND_MTIME_PARAMETER="$FIND_MTIME_PARAMETER -mtime $DATE_RANGE_T2"
-    $DATE_RANGE_CTIME && FIND_CTIME_PARAMETER="$FIND_CTIME_PARAMETER -ctime $DATE_RANGE_T2"
-fi
-
-if [ "$DATE_RANGE_T1" ]; then
-    # process log paths
-    $DATE_RANGE_ATIME && run_cmd "cat \"$CWD/conf/logs.conf\" | grep -v \"^#\" | grep -v \"^$\" | grep \"^/\" | sed 's:^/:'\"$MOUNT_POINT\"'/:; s://*:/:g; s:/$::g' | while read line; do $FIND_TOOL \"\$line\" $FIND_MAXDEPTH_PARAMETER -type f $FIND_SIZE_PARAMETER $FIND_ATIME_PARAMETER ; done" "$COLLECTOR_OUTPUT_DIR/logs.tmp"
-    $DATE_RANGE_MTIME && run_cmd "cat \"$CWD/conf/logs.conf\" | grep -v \"^#\" | grep -v \"^$\" | grep \"^/\" | sed 's:^/:'\"$MOUNT_POINT\"'/:; s://*:/:g; s:/$::g' | while read line; do $FIND_TOOL \"\$line\" $FIND_MAXDEPTH_PARAMETER -type f $FIND_SIZE_PARAMETER $FIND_MTIME_PARAMETER ; done" "$COLLECTOR_OUTPUT_DIR/logs.tmp"
-    $DATE_RANGE_CTIME && run_cmd "cat \"$CWD/conf/logs.conf\" | grep -v \"^#\" | grep -v \"^$\" | grep \"^/\" | sed 's:^/:'\"$MOUNT_POINT\"'/:; s://*:/:g; s:/$::g' | while read line; do $FIND_TOOL \"\$line\" $FIND_MAXDEPTH_PARAMETER -type f $FIND_SIZE_PARAMETER $FIND_CTIME_PARAMETER ; done" "$COLLECTOR_OUTPUT_DIR/logs.tmp"
-    # process log files/directories names
-    $DATE_RANGE_ATIME && run_cmd "cat \"$CWD/conf/logs.conf\" | grep -v \"^#\" | grep -v \"^$\" | grep -v \"^/\" | while read line; do $FIND_TOOL \"$MOUNT_POINT\" -name \"\$line\" $FIND_MAXDEPTH_PARAMETER -type f $FIND_SIZE_PARAMETER $FIND_ATIME_PARAMETER ; done" "$COLLECTOR_OUTPUT_DIR/logs.tmp"
-    $DATE_RANGE_MTIME && run_cmd "cat \"$CWD/conf/logs.conf\" | grep -v \"^#\" | grep -v \"^$\" | grep -v \"^/\" | while read line; do $FIND_TOOL \"$MOUNT_POINT\" -name \"\$line\" $FIND_MAXDEPTH_PARAMETER -type f $FIND_SIZE_PARAMETER $FIND_MTIME_PARAMETER ; done" "$COLLECTOR_OUTPUT_DIR/logs.tmp"
-    $DATE_RANGE_CTIME && run_cmd "cat \"$CWD/conf/logs.conf\" | grep -v \"^#\" | grep -v \"^$\" | grep -v \"^/\" | while read line; do $FIND_TOOL \"$MOUNT_POINT\" -name \"\$line\" $FIND_MAXDEPTH_PARAMETER -type f $FIND_SIZE_PARAMETER $FIND_CTIME_PARAMETER ; done" "$COLLECTOR_OUTPUT_DIR/logs.tmp"               
-else
-    # process log paths
-    run_cmd "cat \"$CWD/conf/logs.conf\" | grep -v \"^#\" | grep -v \"^$\" | grep \"^/\" | sed 's:^/:'\"$MOUNT_POINT\"'/:; s://*:/:g; s:/$::g' | while read line; do $FIND_TOOL \"\$line\" $FIND_MAXDEPTH_PARAMETER -type f $FIND_SIZE_PARAMETER ; done" "$COLLECTOR_OUTPUT_DIR/logs.tmp"
-    # process log files/directories names
-    run_cmd "cat \"$CWD/conf/logs.conf\" | grep -v \"^#\" | grep -v \"^$\" | grep -v \"^/\" | while read line; do $FIND_TOOL \"$MOUNT_POINT\" -name \"\$line\" $FIND_MAXDEPTH_PARAMETER -type f $FIND_SIZE_PARAMETER ; done" "$COLLECTOR_OUTPUT_DIR/logs.tmp"
-fi
-
-# remove any UAC directories from the collection, sort and uniq
-run_cmd "cat \"$COLLECTOR_OUTPUT_DIR/logs.tmp\" | grep -v \"$CWD\" | grep -v \"$DESTINATION_DIR/$TMP_DATA_DIR\" | sort | uniq > \"$COLLECTOR_OUTPUT_DIR/logs.txt\""
-
-# remove temporary files
-run_cmd "rm -f \"$COLLECTOR_OUTPUT_DIR/logs.tmp\""
+# search for log files and directories
+run_cmd "file_search \"$FIND_TOOL\" \"$MOUNT_POINT\" \"$CWD/conf/logs.conf\" \"$COLLECTOR_OUTPUT_DIR/logs.txt\" \"$CWD/conf/exclude.conf\" $LOGS_MAX_DEPTH $LOGS_MAX_FILE_SIZE $DATE_RANGE_T1 $DATE_RANGE_T2"
 
 # compress data
 run_cmd "compress_data \"$COLLECTOR_OUTPUT_DIR/logs.txt\" \"$COLLECTOR_OUTPUT_DIR/logs.tar.$COMPRESS_EXT\" \"$UAC_LOG_FILE\""

--- a/collectors/misc_files
+++ b/collectors/misc_files
@@ -14,51 +14,8 @@
 
 # misc_files collector
 
-FIND_MAXDEPTH_PARAMETER=""
-if [ "$MISC_FILES_MAX_DEPTH" -gt 0 ]; then
-    FIND_MAXDEPTH_PARAMETER="-maxdepth $MISC_FILES_MAX_DEPTH"
-fi
-
-FIND_SIZE_PARAMETER=""
-if [ "$MISC_FILES_MAX_FILE_SIZE" -gt 0 ]; then
-    FIND_SIZE_PARAMETER="-size -${MISC_FILES_MAX_FILE_SIZE}c"
-fi
-
-FIND_ATIME_PARAMETER=""
-FIND_MTIME_PARAMETER=""
-FIND_CTIME_PARAMETER=""
-if [ "$DATE_RANGE_T1" ]; then
-    $DATE_RANGE_ATIME && FIND_ATIME_PARAMETER="-atime $DATE_RANGE_T1"
-    $DATE_RANGE_MTIME && FIND_MTIME_PARAMETER="-mtime $DATE_RANGE_T1"
-    $DATE_RANGE_CTIME && FIND_CTIME_PARAMETER="-ctime $DATE_RANGE_T1"
-fi
-if [ "$DATE_RANGE_T2" ]; then
-    $DATE_RANGE_ATIME && FIND_ATIME_PARAMETER="$FIND_ATIME_PARAMETER -atime $DATE_RANGE_T2"
-    $DATE_RANGE_MTIME && FIND_MTIME_PARAMETER="$FIND_MTIME_PARAMETER -mtime $DATE_RANGE_T2"
-    $DATE_RANGE_CTIME && FIND_CTIME_PARAMETER="$FIND_CTIME_PARAMETER -ctime $DATE_RANGE_T2"
-fi
-
-if [ "$DATE_RANGE_T1" ]; then
-    # process misc files paths
-    $DATE_RANGE_ATIME && run_cmd "cat \"$CWD/conf/misc_files.conf\" | grep -v \"^#\" | grep -v \"^$\" | grep \"^/\" | sed 's:^/:'\"$MOUNT_POINT\"'/:; s://*:/:g; s:/$::g' | while read line; do $FIND_TOOL \"\$line\" $FIND_MAXDEPTH_PARAMETER -type f $FIND_SIZE_PARAMETER $FIND_ATIME_PARAMETER ; done" "$COLLECTOR_OUTPUT_DIR/misc_files.tmp"
-    $DATE_RANGE_MTIME && run_cmd "cat \"$CWD/conf/misc_files.conf\" | grep -v \"^#\" | grep -v \"^$\" | grep \"^/\" | sed 's:^/:'\"$MOUNT_POINT\"'/:; s://*:/:g; s:/$::g' | while read line; do $FIND_TOOL \"\$line\" $FIND_MAXDEPTH_PARAMETER -type f $FIND_SIZE_PARAMETER $FIND_MTIME_PARAMETER ; done" "$COLLECTOR_OUTPUT_DIR/misc_files.tmp"
-    $DATE_RANGE_CTIME && run_cmd "cat \"$CWD/conf/misc_files.conf\" | grep -v \"^#\" | grep -v \"^$\" | grep \"^/\" | sed 's:^/:'\"$MOUNT_POINT\"'/:; s://*:/:g; s:/$::g' | while read line; do $FIND_TOOL \"\$line\" $FIND_MAXDEPTH_PARAMETER -type f $FIND_SIZE_PARAMETER $FIND_CTIME_PARAMETER ; done" "$COLLECTOR_OUTPUT_DIR/misc_files.tmp"
-    # process misc files/directories names
-    $DATE_RANGE_ATIME && run_cmd "cat \"$CWD/conf/misc_files.conf\" | grep -v \"^#\" | grep -v \"^$\" | grep -v \"^/\" | while read line; do $FIND_TOOL \"$MOUNT_POINT\" -name \"\$line\" $FIND_MAXDEPTH_PARAMETER -type f $FIND_SIZE_PARAMETER $FIND_ATIME_PARAMETER ; done" "$COLLECTOR_OUTPUT_DIR/misc_files.tmp"
-    $DATE_RANGE_MTIME && run_cmd "cat \"$CWD/conf/misc_files.conf\" | grep -v \"^#\" | grep -v \"^$\" | grep -v \"^/\" | while read line; do $FIND_TOOL \"$MOUNT_POINT\" -name \"\$line\" $FIND_MAXDEPTH_PARAMETER -type f $FIND_SIZE_PARAMETER $FIND_MTIME_PARAMETER ; done" "$COLLECTOR_OUTPUT_DIR/misc_files.tmp"
-    $DATE_RANGE_CTIME && run_cmd "cat \"$CWD/conf/misc_files.conf\" | grep -v \"^#\" | grep -v \"^$\" | grep -v \"^/\" | while read line; do $FIND_TOOL \"$MOUNT_POINT\" -name \"\$line\" $FIND_MAXDEPTH_PARAMETER -type f $FIND_SIZE_PARAMETER $FIND_CTIME_PARAMETER ; done" "$COLLECTOR_OUTPUT_DIR/misc_files.tmp"               
-else
-    # process log paths
-    run_cmd "cat \"$CWD/conf/misc_files.conf\" | grep -v \"^#\" | grep -v \"^$\" | grep \"^/\" | sed 's:^/:'\"$MOUNT_POINT\"'/:; s://*:/:g; s:/$::g' | while read line; do $FIND_TOOL \"\$line\" $FIND_MAXDEPTH_PARAMETER -type f $FIND_SIZE_PARAMETER ; done" "$COLLECTOR_OUTPUT_DIR/misc_files.tmp"
-    # process log files/directories names
-    run_cmd "cat \"$CWD/conf/misc_files.conf\" | grep -v \"^#\" | grep -v \"^$\" | grep -v \"^/\" | while read line; do $FIND_TOOL \"$MOUNT_POINT\" -name \"\$line\" $FIND_MAXDEPTH_PARAMETER -type f $FIND_SIZE_PARAMETER ; done" "$COLLECTOR_OUTPUT_DIR/misc_files.tmp"
-fi
-
-# remove any UAC directories from the collection, sort and uniq
-run_cmd "cat \"$COLLECTOR_OUTPUT_DIR/misc_files.tmp\" | grep -v \"$CWD\" | grep -v \"$DESTINATION_DIR/$TMP_DATA_DIR\" | sort | uniq > \"$COLLECTOR_OUTPUT_DIR/misc_files.txt\""
-
-# remove temporary files
-run_cmd "rm -f \"$COLLECTOR_OUTPUT_DIR/misc_files.tmp\""
+# search for misc files and directories
+run_cmd "file_search \"$FIND_TOOL\" \"$MOUNT_POINT\" \"$CWD/conf/misc_files.conf\" \"$COLLECTOR_OUTPUT_DIR/misc_files.txt\" \"$CWD/conf/exclude.conf\" $MISC_FILES_MAX_DEPTH $MISC_FILES_MAX_FILE_SIZE $DATE_RANGE_T1 $DATE_RANGE_T2"
 
 # compress data
 run_cmd "compress_data \"$COLLECTOR_OUTPUT_DIR/misc_files.txt\" \"$COLLECTOR_OUTPUT_DIR/misc_files.tar.$COMPRESS_EXT\" \"$UAC_LOG_FILE\""

--- a/collectors/system
+++ b/collectors/system
@@ -78,16 +78,8 @@ if $LIVE_COLLECTION; then
     esac
 fi
 
-# process system_files paths
-run_cmd "cat \"$CWD/conf/system_files.conf\" | grep -v \"^#\" | grep -v \"^$\" | grep \"^/\" | sed 's:^/:'\"$MOUNT_POINT\"'/:; s://*:/:g; s:/$::g' | while read line; do find \"\$line\" -type f ; done" "$COLLECTOR_OUTPUT_DIR/system_files.tmp"
-# process system_files files/directories names
-run_cmd "cat \"$CWD/conf/system_files.conf\" | grep -v \"^#\" | grep -v \"^$\" | grep -v \"^/\" | while read line; do find \"$MOUNT_POINT\" -name \"\$line\" -type f ; done" "$COLLECTOR_OUTPUT_DIR/system_files.tmp"
-
-# remove any UAC directories from the collection, sort and uniq
-run_cmd "cat \"$COLLECTOR_OUTPUT_DIR/system_files.tmp\" | grep -v \"$CWD\" | grep -v \"$DESTINATION_DIR/$TMP_DATA_DIR\" | sort | uniq > \"$COLLECTOR_OUTPUT_DIR/system_files.txt\""
-
-# remove temporary files
-run_cmd "rm -f \"$COLLECTOR_OUTPUT_DIR/system_files.tmp\""
+# search for system files and directories
+run_cmd "file_search \"$FIND_TOOL\" \"$MOUNT_POINT\" \"$CWD/conf/system_files.conf\" \"$COLLECTOR_OUTPUT_DIR/system_files.txt\" \"$CWD/conf/exclude.conf\""
 
 # compress data
 run_cmd "compress_data \"$COLLECTOR_OUTPUT_DIR/system_files.txt\" \"$COLLECTOR_OUTPUT_DIR/system_files.tar.$COMPRESS_EXT\" \"$UAC_LOG_FILE\""

--- a/collectors/user_accounts
+++ b/collectors/user_accounts
@@ -59,11 +59,6 @@ if [ "$PROFILE" = "macos" ]; then
 fi
 
 if [ -s "$COLLECTOR_OUTPUT_DIR/.home_directories.txt" ]; then
-
-    FIND_SIZE_PARAMETER=""
-    if [ "$USER_FILES_MAX_FILE_SIZE" -gt 0 ]; then
-        FIND_SIZE_PARAMETER="-size -${USER_FILES_MAX_FILE_SIZE}c"
-    fi
     
     # cannot use a "while read USER_HOME_DIR; do ... ; done < $COLLECTOR_OUTPUT_DIR/.home_directories.txt" loop here because it does not work properly with Ctrl+C
     cat "$COLLECTOR_OUTPUT_DIR/.home_directories.txt" | while read USER_HOME_DIR; do
@@ -74,50 +69,19 @@ if [ -s "$COLLECTOR_OUTPUT_DIR/.home_directories.txt" ]; then
         # uac will limit the search by setting the -maxdepth to 2
         FIND_MAXDEPTH_PARAMETER=""
         if [ "$USER_HOME_DIR" = "/" ]; then
-            FIND_MAXDEPTH_PARAMETER="-maxdepth 2"
+            FIND_MAXDEPTH_PARAMETER="2"
         else
             if [ "$USER_FILES_MAX_DEPTH" -gt 0 ]; then
-                FIND_MAXDEPTH_PARAMETER="-maxdepth $USER_FILES_MAX_DEPTH"
+                FIND_MAXDEPTH_PARAMETER="$USER_FILES_MAX_DEPTH"
             fi
         fi
 
-        FIND_ATIME_PARAMETER=""
-        FIND_MTIME_PARAMETER=""
-        FIND_CTIME_PARAMETER=""
-        if [ "$DATE_RANGE_T1" ]; then
-            $DATE_RANGE_ATIME && FIND_ATIME_PARAMETER="-atime $DATE_RANGE_T1"
-            $DATE_RANGE_MTIME && FIND_MTIME_PARAMETER="-mtime $DATE_RANGE_T1"
-            $DATE_RANGE_CTIME && FIND_CTIME_PARAMETER="-ctime $DATE_RANGE_T1"
-        fi
-        if [ "$DATE_RANGE_T2" ]; then
-            $DATE_RANGE_ATIME && FIND_ATIME_PARAMETER="$FIND_ATIME_PARAMETER -atime $DATE_RANGE_T2"
-            $DATE_RANGE_MTIME && FIND_MTIME_PARAMETER="$FIND_MTIME_PARAMETER -mtime $DATE_RANGE_T2"
-            $DATE_RANGE_CTIME && FIND_CTIME_PARAMETER="$FIND_CTIME_PARAMETER -ctime $DATE_RANGE_T2"
-        fi
-
-        if [ "$DATE_RANGE_T1" ]; then
-            # process user files paths
-            $DATE_RANGE_ATIME && run_cmd "cat \"$CWD/conf/user_files.conf\" | grep -v \"^#\" | grep -v \"^$\" | grep \"^/\" | sed 's:^/:'\"$USER_HOME_DIR\"'/:; s://*:/:g; s:/$::g' | while read line; do $FIND_TOOL \"\$line\" $FIND_MAXDEPTH_PARAMETER -type f $FIND_SIZE_PARAMETER $FIND_ATIME_PARAMETER ; done" "$COLLECTOR_OUTPUT_DIR/user_files.tmp"
-            $DATE_RANGE_MTIME && run_cmd "cat \"$CWD/conf/user_files.conf\" | grep -v \"^#\" | grep -v \"^$\" | grep \"^/\" | sed 's:^/:'\"$USER_HOME_DIR\"'/:; s://*:/:g; s:/$::g' | while read line; do $FIND_TOOL \"\$line\" $FIND_MAXDEPTH_PARAMETER -type f $FIND_SIZE_PARAMETER $FIND_MTIME_PARAMETER ; done" "$COLLECTOR_OUTPUT_DIR/user_files.tmp"
-            $DATE_RANGE_CTIME && run_cmd "cat \"$CWD/conf/user_files.conf\" | grep -v \"^#\" | grep -v \"^$\" | grep \"^/\" | sed 's:^/:'\"$USER_HOME_DIR\"'/:; s://*:/:g; s:/$::g' | while read line; do $FIND_TOOL \"\$line\" $FIND_MAXDEPTH_PARAMETER -type f $FIND_SIZE_PARAMETER $FIND_CTIME_PARAMETER ; done" "$COLLECTOR_OUTPUT_DIR/user_files.tmp"
-            # process user files/directories names
-            $DATE_RANGE_ATIME && run_cmd "cat \"$CWD/conf/user_files.conf\" | grep -v \"^#\" | grep -v \"^$\" | grep -v \"^/\" | while read line; do $FIND_TOOL \"$USER_HOME_DIR\" -name \"\$line\" $FIND_MAXDEPTH_PARAMETER -type f $FIND_SIZE_PARAMETER $FIND_ATIME_PARAMETER ; done" "$COLLECTOR_OUTPUT_DIR/user_files.tmp"
-            $DATE_RANGE_MTIME && run_cmd "cat \"$CWD/conf/user_files.conf\" | grep -v \"^#\" | grep -v \"^$\" | grep -v \"^/\" | while read line; do $FIND_TOOL \"$USER_HOME_DIR\" -name \"\$line\" $FIND_MAXDEPTH_PARAMETER -type f $FIND_SIZE_PARAMETER $FIND_MTIME_PARAMETER ; done" "$COLLECTOR_OUTPUT_DIR/user_files.tmp"
-            $DATE_RANGE_CTIME && run_cmd "cat \"$CWD/conf/user_files.conf\" | grep -v \"^#\" | grep -v \"^$\" | grep -v \"^/\" | while read line; do $FIND_TOOL \"$USER_HOME_DIR\" -name \"\$line\" $FIND_MAXDEPTH_PARAMETER -type f $FIND_SIZE_PARAMETER $FIND_CTIME_PARAMETER ; done" "$COLLECTOR_OUTPUT_DIR/user_files.tmp"
-        else
-            # process user files paths
-            run_cmd "cat \"$CWD/conf/user_files.conf\" | grep -v \"^#\" | grep -v \"^$\" | grep \"^/\" | sed 's:^/:'\"$USER_HOME_DIR\"'/:; s://*:/:g; s:/$::g' | while read line; do $FIND_TOOL \"\$line\" $FIND_MAXDEPTH_PARAMETER -type f $FIND_SIZE_PARAMETER ; done" "$COLLECTOR_OUTPUT_DIR/user_files.tmp"
-            # process user files/directories names
-            run_cmd "cat \"$CWD/conf/user_files.conf\" | grep -v \"^#\" | grep -v \"^$\" | grep -v \"^/\" | while read line; do $FIND_TOOL \"$USER_HOME_DIR\" -name \"\$line\" $FIND_MAXDEPTH_PARAMETER -type f $FIND_SIZE_PARAMETER ; done" "$COLLECTOR_OUTPUT_DIR/user_files.tmp"
-        fi
+        # search for log files and directories
+        run_cmd "file_search \"$FIND_TOOL\" \"$USER_HOME_DIR\" \"$CWD/conf/user_files.conf\" \"$COLLECTOR_OUTPUT_DIR/user_files.txt\" \"$CWD/conf/exclude.conf\" $FIND_MAXDEPTH_PARAMETER $USER_FILES_MAX_FILE_SIZE $DATE_RANGE_T1 $DATE_RANGE_T2"
+        
     done
-
-    # remove any UAC directories from the collection, sort and uniq
-    run_cmd "cat \"$COLLECTOR_OUTPUT_DIR/user_files.tmp\" | grep -v \"$CWD\" | grep -v \"$DESTINATION_DIR/$TMP_DATA_DIR\" | sort | uniq > \"$COLLECTOR_OUTPUT_DIR/user_files.txt\""
-
-    # remove temporary files
-    run_cmd "rm -f \"$COLLECTOR_OUTPUT_DIR/user_files.tmp\""
 
     # compress data
     run_cmd "compress_data \"$COLLECTOR_OUTPUT_DIR/user_files.txt\" \"$COLLECTOR_OUTPUT_DIR/user_files.tar.$COMPRESS_EXT\" \"$UAC_LOG_FILE\""
+
 fi

--- a/conf/exclude.conf
+++ b/conf/exclude.conf
@@ -1,0 +1,20 @@
+# Directory or file paths that will be excluded from logs, misc_files, user_files and system_files collectors.
+# If a directory path is added, all files and subdirectories will be excluded automatically.
+#
+# Directory and file names with spaces are supported. Do not quote or double quote them.
+# Examples:
+# /dev/directory with spaces
+# /dev/block/file name with spaces
+#
+# Wildcards are not supported. Only full paths should be added here.
+#
+/dev
+/proc
+/sys
+
+# File and directory names that will be excluded from logs, misc_files, user_files and system_files collector.
+#
+# The 'find' command line tool will be used to search for files and directories,
+# so the patterns below need to be compatible with the -name option.
+# Please check 'find' man pages for instructions.
+uac-*

--- a/conf/uac.conf
+++ b/conf/uac.conf
@@ -6,41 +6,6 @@
 # default: "/"
 MOUNT_POINT="/"
 
-# set the max depth for the body_file (-b) collector
-# accepted values: unsigned integer (0: unlimited)
-# default: 4
-BODY_FILE_MAX_DEPTH=4
-
-# set the max depth for the logs (-l) collector
-# accepted values: unsigned integer (0: unlimited)
-# default: 0
-LOGS_MAX_DEPTH=0
-
-# set the max file size (in bytes) for log files
-# accepted values: unsigned integer (0: unlimited)
-# default: 0
-LOGS_MAX_FILE_SIZE=0
-
-# set the max depth for the misc_files (-f) collector
-# accepted values: unsigned integer (0: unlimited)
-# default: 0
-MISC_FILES_MAX_DEPTH=0
-
-# set the max file size (in bytes) for misc files
-# accepted values: unsigned integer (0: unlimited)
-# default: 0
-MISC_FILES_MAX_FILE_SIZE=0
-
-# set the max depth for the user_accounts (-u) collector
-# accepted values: unsigned integer (0: unlimited)
-# default: 4
-USER_FILES_MAX_DEPTH=4
-
-# set the max file size (in bytes) for user files
-# accepted values: unsigned integer (0: unlimited)
-# default: 0
-USER_FILES_MAX_FILE_SIZE=0
-
 # when a date range is set using -R option, UAC will use find's -atime, -mtime or -ctime parameters
 # to limit the amount of data collected by logs (-l) and misc_files (-f) collectors.
 # UAC will perform a find for each enabled option, which means it will search for files that were
@@ -51,3 +16,63 @@ USER_FILES_MAX_FILE_SIZE=0
 DATE_RANGE_ATIME=false
 DATE_RANGE_MTIME=true
 DATE_RANGE_CTIME=true
+
+#SKIP_FILE_SYSTEM="nfs,cifs,proc,tmpfs"
+
+### body file collector
+# set the max depth for the body_file (-b) collector
+# accepted values: unsigned integer (0: unlimited)
+# default: 4
+BODY_FILE_MAX_DEPTH=4
+
+### logs collector
+# set the max depth for the logs (-l) collector
+# accepted values: unsigned integer (0: unlimited)
+# default: 0
+LOGS_MAX_DEPTH=0
+
+# set the max file size (in bytes) for log files
+# accepted values: unsigned integer (0: unlimited)
+# default: 0
+LOGS_MAX_FILE_SIZE=0
+
+#LOGS_SKIP_DATE_RANGE=false
+
+### suspicious files collector
+# set the max depth for the misc_files (-f) collector
+# accepted values: unsigned integer (0: unlimited)
+# default: 0
+MISC_FILES_MAX_DEPTH=0
+
+# set the max file size (in bytes) for misc files
+# accepted values: unsigned integer (0: unlimited)
+# default: 3072000
+MISC_FILES_MAX_FILE_SIZE=3072000
+
+#MISC_FILES_SKIP_DATE_RANGE=false
+
+### system files collector
+# set the max depth for the system_files (-f) collector
+# accepted values: unsigned integer (0: unlimited)
+# default: 0
+SYSTEM_FILES_MAX_DEPTH=0
+
+# set the max file size (in bytes) for misc files
+# accepted values: unsigned integer (0: unlimited)
+# default: 0
+SYSTEM_FILES_MAX_FILE_SIZE=0
+
+#SYSTEM_FILES_SKIP_DATE_RANGE=true
+
+### user files collector
+# set the max depth for the user_accounts (-u) collector
+# accepted values: unsigned integer (0: unlimited)
+# default: 0
+USER_FILES_MAX_DEPTH=0
+
+# set the max file size (in bytes) for user files
+# accepted values: unsigned integer (0: unlimited)
+# default: 0
+USER_FILES_MAX_FILE_SIZE=0
+
+#USER_FILES_SKIP_DATE_RANGE=false

--- a/lib/file_search.lib
+++ b/lib/file_search.lib
@@ -1,0 +1,118 @@
+################################################################################
+# NAME
+#   file_search - search for files and directories based on a set of criteria
+# SYNOPSIS
+#   file_search FIND_TOOL MOUNT_POINT INPUT_FILE OUTPUT_FILE [EXCLUDE_FILE] [MAXDEPTH] [SIZE] [DATE_RANGE_T1] [DATE_RANGE_T2]
+# OPTIONS
+#   FIND_TOOL       find or perl "$CWD/tools/find/find.pl"
+#   MOUNT_POINT     starting point
+#   INPUT_FILE      input file name containing a list of file and/or directory
+#                   names to be searched for
+#   OUTPUT_FILE     output file name
+#   EXCLUDE_FILE    file containing a list of file and/or directory names
+#                   to be excluded from the search
+#   MAXDEPTH        value to be used with -maxdepth
+#   SIZE            value to be used with -size
+#   DATE_RANGE_T1   value to be used with -atime, -mtime and -ctime
+#   DATE_RANGE_T2   value to be used with -atime, -mtime and -ctime
+# RETURN VALUE
+#   file containing the list of file names found during the search
+################################################################################
+file_search() {
+
+    LOCAL_FIND_TOOL="$1"
+    LOCAL_MOUNT_POINT="$2"
+    LOCAL_INPUT_FILE="$3"
+    LOCAL_OUTPUT_FILE="$4"
+    LOCAL_EXCLUDE_FILE="$5"
+    LOCAL_FIND_MAXDEPTH=$6
+    LOCAL_FIND_SIZE=$7
+    LOCAL_DATE_RANGE_T1=$8
+    LOCAL_DATE_RANGE_T2=$9
+
+    LOCAL_FIND_NAME_PARAMETER=""
+    LOCAL_FIND_PATH_PRUNE_PARAMETER=""
+    LOCAL_FIND_NAME_PRUNE_PARAMETER=""
+    LOCAL_FIND_MAXDEPTH_PARAMETER=""
+    LOCAL_FIND_SIZE_PARAMETER=""
+
+    if [ -f "$LOCAL_INPUT_FILE" ]; then
+
+        LOCAL_FIND_NAME_PARAMETER=`cat "$LOCAL_INPUT_FILE" | grep -v "^#" | grep -v "^$" | grep -v "^/" | head -1 | while read line; do printf %s "-name \"$line\""; done; cat "$LOCAL_INPUT_FILE" | grep -v "^#" | grep -v "^$" | grep -v "^/" | sed 1d | while read line; do printf %s " -o -name \"$line\"" ;done`
+        if [ ! -z "$LOCAL_FIND_NAME_PARAMETER" ]; then
+            LOCAL_FIND_NAME_PARAMETER="\( $LOCAL_FIND_NAME_PARAMETER \)"
+        fi
+
+        if [ -f "$LOCAL_EXCLUDE_FILE" ]; then
+            LOCAL_FIND_PATH_PRUNE_PARAMETER=`cat "$LOCAL_EXCLUDE_FILE" | grep -v "^#" | grep -v "^$" | grep "^/" | head -1 | sed 's:^/:'"$LOCAL_MOUNT_POINT"'/:; s://*:/:g; s:/$::g' | while read line; do printf %s "-path \"$line\""; done; cat "$LOCAL_EXCLUDE_FILE" | grep -v "^#" | grep -v "^$" | grep "^/" | sed 1d | sed 's:^/:'"$LOCAL_MOUNT_POINT"'/:; s://*:/:g; s:/$::g' | while read line; do printf %s " -o -path \"$line\"" ;done`
+            if [ ! -z "$LOCAL_FIND_PATH_PRUNE_PARAMETER" ]; then
+                LOCAL_FIND_PATH_PRUNE_PARAMETER="\( $LOCAL_FIND_PATH_PRUNE_PARAMETER \) -prune -o"
+            fi
+            LOCAL_FIND_NAME_PRUNE_PARAMETER=`cat "$LOCAL_EXCLUDE_FILE" | grep -v "^#" | grep -v "^$" | grep -v "^/" | head -1 | while read line; do printf %s "-name \"$line\""; done; cat "$LOCAL_EXCLUDE_FILE" | grep -v "^#" | grep -v "^$" | grep -v "^/" | sed 1d | while read line; do printf %s " -o -name \"$line\"" ;done`
+            if [ ! -z "$LOCAL_FIND_NAME_PRUNE_PARAMETER" ]; then
+                LOCAL_FIND_NAME_PRUNE_PARAMETER="\( $LOCAL_FIND_NAME_PRUNE_PARAMETER \) -prune -o"
+            fi
+        fi
+
+        if [ "$LOCAL_FIND_MAXDEPTH" -gt 0 ]; then
+            LOCAL_FIND_MAXDEPTH_PARAMETER="-maxdepth $LOCAL_FIND_MAXDEPTH"
+        fi
+        
+        if [ "$LOCAL_FIND_SIZE" -gt 0 ]; then
+            LOCAL_FIND_SIZE_PARAMETER="-size -${LOCAL_FIND_SIZE}c"
+        fi
+
+        # first we need to search for directories which names were added to LOCAL_INPUT_FILE
+        if [ ! -z "$LOCAL_FIND_NAME_PARAMETER" ]; then
+            run_cmd "$LOCAL_FIND_TOOL \"$LOCAL_MOUNT_POINT\" $LOCAL_FIND_MAXDEPTH_PARAMETER $LOCAL_FIND_PATH_PRUNE_PARAMETER $LOCAL_FIND_NAME_PRUNE_PARAMETER $LOCAL_FIND_NAME_PARAMETER -type d -print" "$DESTINATION_DIR/$TMP_DATA_DIR/.file_search_paths.tmp"
+        fi
+        # then merge the paths with the ones added to LOCAL_INPUT_FILE
+        run_cmd "cat \"$LOCAL_INPUT_FILE\" | grep -v \"^#\" | grep -v \"^$\" | grep \"^/\" | sed 's:^/:'\"$LOCAL_MOUNT_POINT\"'/:; s://*:/:g; s:/$::g'" "$DESTINATION_DIR/$TMP_DATA_DIR/.file_search_paths.tmp"       
+        run_cmd "cat \"$DESTINATION_DIR/$TMP_DATA_DIR/.file_search_paths.tmp\" | sort | uniq" "$DESTINATION_DIR/$TMP_DATA_DIR/.file_search_paths_sort_uniq.tmp"
+        
+        if [ "$LOCAL_DATE_RANGE_T1" ]; then
+
+            LOCAL_FIND_ATIME_PARAMETER=""
+            LOCAL_FIND_MTIME_PARAMETER=""
+            LOCAL_FIND_CTIME_PARAMETER=""
+            
+            $DATE_RANGE_ATIME && LOCAL_FIND_ATIME_PARAMETER="-atime $LOCAL_DATE_RANGE_T1"
+            $DATE_RANGE_MTIME && LOCAL_FIND_MTIME_PARAMETER="-mtime $LOCAL_DATE_RANGE_T1"
+            $DATE_RANGE_CTIME && LOCAL_FIND_CTIME_PARAMETER="-ctime $LOCAL_DATE_RANGE_T1"
+            
+            if [ "$LOCAL_DATE_RANGE_T2" ]; then
+                $DATE_RANGE_ATIME && LOCAL_FIND_ATIME_PARAMETER="$LOCAL_FIND_ATIME_PARAMETER -atime $LOCAL_DATE_RANGE_T2"
+                $DATE_RANGE_MTIME && LOCAL_FIND_MTIME_PARAMETER="$LOCAL_FIND_MTIME_PARAMETER -mtime $LOCAL_DATE_RANGE_T2"
+                $DATE_RANGE_CTIME && LOCAL_FIND_CTIME_PARAMETER="$LOCAL_FIND_CTIME_PARAMETER -ctime $LOCAL_DATE_RANGE_T2"
+            fi
+
+            # search through paths
+            $DATE_RANGE_ATIME && run_cmd "cat \"$DESTINATION_DIR/$TMP_DATA_DIR/.file_search_paths_sort_uniq.tmp\" | while read line; do $LOCAL_FIND_TOOL \"\$line\" $LOCAL_FIND_MAXDEPTH_PARAMETER $LOCAL_FIND_PATH_PRUNE_PARAMETER $LOCAL_FIND_NAME_PRUNE_PARAMETER -type f $LOCAL_FIND_SIZE_PARAMETER $LOCAL_FIND_ATIME_PARAMETER -print; done" "${LOCAL_OUTPUT_FILE}.tmp"
+            $DATE_RANGE_MTIME && run_cmd "cat \"$DESTINATION_DIR/$TMP_DATA_DIR/.file_search_paths_sort_uniq.tmp\" | while read line; do $LOCAL_FIND_TOOL \"\$line\" $LOCAL_FIND_MAXDEPTH_PARAMETER $LOCAL_FIND_PATH_PRUNE_PARAMETER $LOCAL_FIND_NAME_PRUNE_PARAMETER -type f $LOCAL_FIND_SIZE_PARAMETER $LOCAL_FIND_MTIME_PARAMETER -print; done" "${LOCAL_OUTPUT_FILE}.tmp"
+            $DATE_RANGE_CTIME && run_cmd "cat \"$DESTINATION_DIR/$TMP_DATA_DIR/.file_search_paths_sort_uniq.tmp\" | while read line; do $LOCAL_FIND_TOOL \"\$line\" $LOCAL_FIND_MAXDEPTH_PARAMETER $LOCAL_FIND_PATH_PRUNE_PARAMETER $LOCAL_FIND_NAME_PRUNE_PARAMETER -type f $LOCAL_FIND_SIZE_PARAMETER $LOCAL_FIND_CTIME_PARAMETER -print; done" "${LOCAL_OUTPUT_FILE}.tmp"
+            # search for the file names added to LOCAL_INPUT_FILE
+            if [ ! -z "$LOCAL_FIND_NAME_PARAMETER" ]; then
+                $DATE_RANGE_ATIME && run_cmd "$LOCAL_FIND_TOOL \"$LOCAL_MOUNT_POINT\" $LOCAL_FIND_MAXDEPTH_PARAMETER $LOCAL_FIND_PATH_PRUNE_PARAMETER $LOCAL_FIND_NAME_PRUNE_PARAMETER $LOCAL_FIND_NAME_PARAMETER -type f $LOCAL_FIND_SIZE_PARAMETER $LOCAL_FIND_ATIME_PARAMETER -print" "${LOCAL_OUTPUT_FILE}.tmp"
+                $DATE_RANGE_MTIME && run_cmd "$LOCAL_FIND_TOOL \"$LOCAL_MOUNT_POINT\" $LOCAL_FIND_MAXDEPTH_PARAMETER $LOCAL_FIND_PATH_PRUNE_PARAMETER $LOCAL_FIND_NAME_PRUNE_PARAMETER $LOCAL_FIND_NAME_PARAMETER -type f $LOCAL_FIND_SIZE_PARAMETER $LOCAL_FIND_MTIME_PARAMETER -print" "${LOCAL_OUTPUT_FILE}.tmp"
+                $DATE_RANGE_CTIME && run_cmd "$LOCAL_FIND_TOOL \"$LOCAL_MOUNT_POINT\" $LOCAL_FIND_MAXDEPTH_PARAMETER $LOCAL_FIND_PATH_PRUNE_PARAMETER $LOCAL_FIND_NAME_PRUNE_PARAMETER $LOCAL_FIND_NAME_PARAMETER -type f $LOCAL_FIND_SIZE_PARAMETER $LOCAL_FIND_CTIME_PARAMETER -print" "${LOCAL_OUTPUT_FILE}.tmp"
+            fi
+
+        else
+            # search through paths
+            run_cmd "cat \"$DESTINATION_DIR/$TMP_DATA_DIR/.file_search_paths_sort_uniq.tmp\" | while read line; do $LOCAL_FIND_TOOL \"\$line\" $LOCAL_FIND_MAXDEPTH_PARAMETER $LOCAL_FIND_PATH_PRUNE_PARAMETER $LOCAL_FIND_NAME_PRUNE_PARAMETER -type f $LOCAL_FIND_SIZE_PARAMETER -print; done" "${LOCAL_OUTPUT_FILE}.tmp"
+            # search for the file names added to LOCAL_INPUT_FILE
+            if [ ! -z "$LOCAL_FIND_NAME_PARAMETER" ]; then
+                run_cmd "$LOCAL_FIND_TOOL \"$LOCAL_MOUNT_POINT\" $LOCAL_FIND_MAXDEPTH_PARAMETER $LOCAL_FIND_PATH_PRUNE_PARAMETER $LOCAL_FIND_NAME_PRUNE_PARAMETER $LOCAL_FIND_NAME_PARAMETER -type f $LOCAL_FIND_SIZE_PARAMETER -print" "${LOCAL_OUTPUT_FILE}.tmp"
+            fi
+        fi
+
+        # remove UAC directory from the collection, sort and uniq
+        run_cmd "cat \"${LOCAL_OUTPUT_FILE}.tmp\" | grep -v \"$CWD\" | sort | uniq" "$LOCAL_OUTPUT_FILE"
+
+        # remove temporary files
+        run_cmd "rm -f \"$DESTINATION_DIR/$TMP_DATA_DIR/.file_search_paths.tmp\""
+        run_cmd "rm -f \"$DESTINATION_DIR/$TMP_DATA_DIR/.file_search_paths_sort_uniq.tmp\""
+        run_cmd "rm -f \"${LOCAL_OUTPUT_FILE}.tmp\""
+
+    fi
+}


### PR DESCRIPTION
all files collectors, such as logs, misc_files, system_files and user_files were updated to use the new file_search lib.
exclude.conf was created to exclude paths and file names from the collection.
find.pl was updated to support expressions and new options.

Signed-off-by: Thiago Lahr <tclahr@br.ibm.com>