### PR TITLE
changes to files collectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## 1.2.0-dev
 
-
+- Files and directories can be excluded from collection if added to ```conf/exclude.conf``` file.
 
 ## 1.1.1 (2020-06-16)
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ The ```find``` command line tool will be used to search for files and directorie
 Directory or file paths that will be searched and collected by the user_accounts (-u) collector. If a directory path is added, all files and subdirectories will be collected automatically.
 The ```find``` command line tool will be used to search for files and directories, so the patterns added to this file need to be compatible with the ```-name``` option. Please check ```find``` man pages for instructions.
 
+### conf/exclude.conf
+Directory or file paths that will be excluded from logs, user, system and suspicious files collectors. If a directory path is added, all files and subdirectories will be skilled automatically.
+The ```find``` command line tool will be used to search for files and directories, so the patterns added to this file need to be compatible with ```-path``` and ```-name``` options. Please check ```find``` man pages for instructions.
+
 ## Usage
 ```
 UAC (Unix-like Artifacts Collector)


### PR DESCRIPTION
all files collectors, such as logs, misc_files, system_files and user_files were updated to use the new file_search lib.
exclude.conf was created to exclude paths and file names from the collection.

Signed-off-by: Thiago Lahr <tclahr@br.ibm.com>