### PR TITLE
Quote find output to avoid issues with quotes when piping to xargs

### DIFF
--- a/lib/find_wrapper.sh
+++ b/lib/find_wrapper.sh
@@ -341,7 +341,7 @@ ${fw_find_type_param} \
 ${fw_find_min_file_size_param} \
 ${fw_find_max_file_size_param} \
 ${fw_find_perm_param} \
-${fw_find_date_range_param} -print"
+${fw_find_date_range_param} -printf '\"%p\"\\\n'"
       eval "${fw_find_tool} \
 ${fw_path} \
 ${fw_find_max_depth_param} \
@@ -353,7 +353,7 @@ ${fw_find_type_param} \
 ${fw_find_min_file_size_param} \
 ${fw_find_max_file_size_param} \
 ${fw_find_perm_param} \
-${fw_find_date_range_param} -print"
+${fw_find_date_range_param} -printf '\"%p\"\\\n'"
     else
       # if operators are not supported, 'find' will be run for each -name value
       echo "${fw_name_pattern}" \
@@ -374,7 +374,7 @@ ${fw_find_path_param} \
 ${fw_find_min_file_size_param} \
 ${fw_find_max_file_size_param} \
 ${fw_find_perm_param} \
-${fw_find_date_range_param} -print"
+${fw_find_date_range_param} -printf '\"%p\"\\\n'"
             eval "${fw_find_tool} \
 ${fw_path} \
 ${fw_find_max_depth_param} \
@@ -383,7 +383,7 @@ ${fw_find_path_param} \
 ${fw_find_min_file_size_param} \
 ${fw_find_max_file_size_param} \
 ${fw_find_perm_param} \
-${fw_find_date_range_param} -print"
+${fw_find_date_range_param} -printf '\"%p\"\\\n'"
           done
     fi
   else
@@ -397,7 +397,7 @@ ${fw_find_type_param} \
 ${fw_find_min_file_size_param} \
 ${fw_find_max_file_size_param} \
 ${fw_find_perm_param} \
-${fw_find_date_range_param} -print"
+${fw_find_date_range_param} -printf '\"%p\"\\\n'"
     eval "${fw_find_tool} \
 ${fw_path} \
 ${fw_find_max_depth_param} \


### PR DESCRIPTION
I've run into issues when filenames contain single quote chars
```
xargs: unmatched single quote; by default quotes are special to xargs unless you use the -0 option
```

This adds quotes to find output (but I dont know if printf works cross platform like this?)


Way to reproduce:

```shell
$ touch something\'
$ ./uac -a bodyfile .
``` 
inspect the bodyfile.txt.stderr and see the `xargs` error

