### PR TITLE
fix: remove /* from path

### DIFF
--- a/artifacts/files/applications/addressbook.yaml
+++ b/artifacts/files/applications/addressbook.yaml
@@ -10,12 +10,12 @@ artifacts:
     description: Collect AddressBook Metadata files.
     supported_os: [macos]
     collector: file
-    path: /%user_home%/Library/"Application Support"/AddressBook/Metadata/*
+    path: /%user_home%/Library/"Application Support"/AddressBook/Metadata
     exclude_nologin_users: true
   -
     description: Collect AddressBook Image files.
     supported_os: [macos]
     collector: file
-    path: /%user_home%/Library/"Application Support"/AddressBook/Images/*
+    path: /%user_home%/Library/"Application Support"/AddressBook/Images
     exclude_nologin_users: true
     

--- a/artifacts/files/applications/aspera_connect.yaml
+++ b/artifacts/files/applications/aspera_connect.yaml
@@ -4,13 +4,13 @@ artifacts:
     description: Collect Aspera Client file lists.
     supported_os: [linux, macos]
     collector: file
-    path: /%user_home%/.aspera/connect/filelists/*
+    path: /%user_home%/.aspera/connect/filelists
     exclude_nologin_users: true
   -
     description: Collect Aspera Client logs.
     supported_os: [linux, macos]
     collector: file
-    path: /%user_home%/.aspera/connect/var/log/*
+    path: /%user_home%/.aspera/connect/var/log
     exclude_nologin_users: true
   -
     description: Collect Aspera Client sqlite database.

--- a/artifacts/files/applications/discord.yaml
+++ b/artifacts/files/applications/discord.yaml
@@ -25,13 +25,13 @@ artifacts:
     description: Collect Discord cache files.
     supported_os: [macos]
     collector: file
-    path: /%user_home%/Library/"Application Support"/discord/Cache/*
+    path: /%user_home%/Library/"Application Support"/discord/Cache
     exclude_nologin_users: true
   -
     description: Collect Discord leveldb files.
     supported_os: [macos]
     collector: file
-    path: /%user_home%/Library/"Application Support"/discord/"Local Storage"/leveldb/*
+    path: /%user_home%/Library/"Application Support"/discord/"Local Storage"/leveldb
     exclude_nologin_users: true
 
 # Discord is a cloud-based application. All chats are in the cloud.

--- a/artifacts/files/applications/dropbox.yaml
+++ b/artifacts/files/applications/dropbox.yaml
@@ -4,7 +4,7 @@ artifacts:
     description: Collect Dropbox Cloud Storage metadata.
     supported_os: [linux, macos]
     collector: file
-    path: /%user_home%/.dropbox/*
+    path: /%user_home%/.dropbox
     file_type: f
     ignore_date_range: true
     exclude_nologin_users: true

--- a/artifacts/files/applications/filezilla.yaml
+++ b/artifacts/files/applications/filezilla.yaml
@@ -4,7 +4,7 @@ artifacts:
     description: Collect FileZilla XML and sqlite files.
     supported_os: [linux, macos]
     collector: file
-    path: /%user_home%/.config/filezilla/*
+    path: /%user_home%/.config/filezilla
     name_pattern: ["*.xml*", "*.sqlite3*"]
     file_type: f
     ignore_date_range: true
@@ -13,7 +13,7 @@ artifacts:
     description: Collect FileZilla XML and sqlite files (Flatpak version).
     supported_os: [linux]
     collector: file
-    path: /%user_home%/.var/app/org.filezillaproject.Filezilla/*
+    path: /%user_home%/.var/app/org.filezillaproject.Filezilla
     name_pattern: ["*.xml*", "*.sqlite3*"]
     file_type: f
     ignore_date_range: true

--- a/artifacts/files/applications/icloud.yaml
+++ b/artifacts/files/applications/icloud.yaml
@@ -4,7 +4,7 @@ artifacts:
     description: Collect iCloud accounts information files.
     supported_os: [macos]
     collector: file
-    path: /%user_home%/Library/"Application Support"/iCloud/Accounts/*
+    path: /%user_home%/Library/"Application Support"/iCloud/Accounts
     exclude_nologin_users: true
   -
     description: Collect iCloud local databases that contain information about files that have been imported from the local computer or synced remotely from the iCloud.

--- a/artifacts/files/applications/imessage.yaml
+++ b/artifacts/files/applications/imessage.yaml
@@ -10,6 +10,6 @@ artifacts:
     description: Collect iMessage attachments.
     supported_os: [macos]
     collector: file
-    path: /%user_home%/Library/Messages/Attachments/*
+    path: /%user_home%/Library/Messages/Attachments
     exclude_nologin_users: true
   

--- a/artifacts/files/applications/itunes_backup.yaml
+++ b/artifacts/files/applications/itunes_backup.yaml
@@ -4,6 +4,6 @@ artifacts:
     description: iTunes backup directory.
     supported_os: [macos]
     collector: file
-    path: /%user_home%/Library/"Application Support"/MobileSync/Backup/*
+    path: /%user_home%/Library/"Application Support"/MobileSync/Backup
     exclude_nologin_users: true
     

--- a/artifacts/files/applications/microsoft_teams.yaml
+++ b/artifacts/files/applications/microsoft_teams.yaml
@@ -4,7 +4,7 @@ artifacts:
     description: Collect Microsoft Teams cache files.
     supported_os: [linux]
     collector: file
-    path: /%user_home%/.config/Microsoft/"Microsoft Teams"/Cache/*
+    path: /%user_home%/.config/Microsoft/"Microsoft Teams"/Cache
     exclude_nologin_users: true
   -
     description: Collect Microsoft Teams chat log files.
@@ -17,7 +17,7 @@ artifacts:
     description: Collect Microsoft Teams leveldb files.
     supported_os: [linux]
     collector: file
-    path: /%user_home%/.config/Microsoft/"Microsoft Teams"/"Local Storage"/leveldb/*
+    path: /%user_home%/.config/Microsoft/"Microsoft Teams"/"Local Storage"/leveldb
     exclude_nologin_users: true
   -
     description: Collect Microsoft Teams config file.
@@ -29,7 +29,7 @@ artifacts:
     description: Collect Microsoft Teams logs directory.
     supported_os: [linux]
     collector: file
-    path: /%user_home%/.config/Microsoft/"Microsoft Teams"/logs/*
+    path: /%user_home%/.config/Microsoft/"Microsoft Teams"/logs
     exclude_nologin_users: true
   -
     description: Collect Microsoft Teams log file.
@@ -127,7 +127,7 @@ artifacts:
     description: Collect Microsoft Teams cache files.
     supported_os: [macos]
     collector: file
-    path: /%user_home%/Library/"Application Support"/Microsoft/Teams/Cache/*
+    path: /%user_home%/Library/"Application Support"/Microsoft/Teams/Cache
     exclude_nologin_users: true
   -
     description: Collect Microsoft Teams chat log files.
@@ -140,7 +140,7 @@ artifacts:
     description: Collect Microsoft Teams leveldb files.
     supported_os: [macos]
     collector: file
-    path: /%user_home%/Library/"Application Support"/Microsoft/Teams/"Local Storage"/leveldb/*
+    path: /%user_home%/Library/"Application Support"/Microsoft/Teams/"Local Storage"/leveldb
     exclude_nologin_users: true
   -
     description: Collect Microsoft Teams config file.
@@ -152,7 +152,7 @@ artifacts:
     description: Collect Microsoft Teams logs directory.
     supported_os: [macos]
     collector: file
-    path: /%user_home%/Library/"Application Support"/Microsoft/Teams/logs/*
+    path: /%user_home%/Library/"Application Support"/Microsoft/Teams/logs
     exclude_nologin_users: true
   -
     description: Collect Microsoft Teams log file.

--- a/artifacts/files/applications/signal.yaml
+++ b/artifacts/files/applications/signal.yaml
@@ -4,19 +4,19 @@ artifacts:
     description: Collect Signal cache files.
     supported_os: [linux]
     collector: file
-    path: /%user_home%/.config/Signal/Cache/*
+    path: /%user_home%/.config/Signal/Cache
     exclude_nologin_users: true
   -
     description: Collect Signal attachments cache files.
     supported_os: [linux]
     collector: file
-    path: /%user_home%/.config/Signal/attachments.noindex/*
+    path: /%user_home%/.config/Signal/attachments.noindex
     exclude_nologin_users: true
   -
     description: Collect Signal log files.
     supported_os: [linux]
     collector: file
-    path: /%user_home%/.config/Signal/logs/*
+    path: /%user_home%/.config/Signal/logs
     exclude_nologin_users: true
   -
     description: Collect Signal config.json file.
@@ -107,19 +107,19 @@ artifacts:
     description: Collect Signal cache files.
     supported_os: [macos]
     collector: file
-    path: /%user_home%/Library/"Application Support"/Signal/Cache/*
+    path: /%user_home%/Library/"Application Support"/Signal/Cache
     exclude_nologin_users: true
   -
     description: Collect Signal attachments cache files.
     supported_os: [macos]
     collector: file
-    path: /%user_home%/Library/"Application Support"/Signal/attachments.noindex/*
+    path: /%user_home%/Library/"Application Support"/Signal/attachments.noindex
     exclude_nologin_users: true
   -
     description: Collect Signal log files.
     supported_os: [macos]
     collector: file
-    path: /%user_home%/Library/"Application Support"/Signal/logs/*
+    path: /%user_home%/Library/"Application Support"/Signal/logs
     exclude_nologin_users: true
   -
     description: Collect Signal config.json file.

--- a/artifacts/files/applications/slack.yaml
+++ b/artifacts/files/applications/slack.yaml
@@ -4,7 +4,7 @@ artifacts:
     description: Collect Slack cache files.
     supported_os: [linux]
     collector: file
-    path: /%user_home%/.config/Slack/Cache/*
+    path: /%user_home%/.config/Slack/Cache
     exclude_nologin_users: true
   -
     description: Collect Slack chat log files.
@@ -17,19 +17,19 @@ artifacts:
     description: Collect Slack leveldb files.
     supported_os: [linux]
     collector: file
-    path: /%user_home%/.config/Slack/"Local Storage"/leveldb/*
+    path: /%user_home%/.config/Slack/"Local Storage"/leveldb
     exclude_nologin_users: true
   -
     description: Collect Slack log files.
     supported_os: [linux]
     collector: file
-    path: /%user_home%/.config/Slack/logs/*
+    path: /%user_home%/.config/Slack/logs
     exclude_nologin_users: true
   -
     description: Collect Slack storage files.
     supported_os: [linux]
     collector: file
-    path: /%user_home%/.config/Slack/storage/*
+    path: /%user_home%/.config/Slack/storage
     exclude_nologin_users: true
   -
     description: Collect Slack cache files (Flatpak version).
@@ -107,7 +107,7 @@ artifacts:
     description: Collect Slack cache files.
     supported_os: [macos]
     collector: file
-    path: /%user_home%/Library/"Application Support"/Slack/Cache/*
+    path: /%user_home%/Library/"Application Support"/Slack/Cache
     exclude_nologin_users: true
   -
     description: Collect Slack chat log files.
@@ -120,19 +120,19 @@ artifacts:
     description: Collect Slack leveldb files.
     supported_os: [macos]
     collector: file
-    path: /%user_home%/Library/"Application Support"/Slack/"Local Storage"/leveldb/*
+    path: /%user_home%/Library/"Application Support"/Slack/"Local Storage"/leveldb
     exclude_nologin_users: true
   -
     description: Collect Slack log files.
     supported_os: [macos]
     collector: file
-    path: /%user_home%/Library/"Application Support"/Slack/logs/*
+    path: /%user_home%/Library/"Application Support"/Slack/logs
     exclude_nologin_users: true
   -
     description: Collect Slack storage files.
     supported_os: [macos]
     collector: file
-    path: /%user_home%/Library/"Application Support"/Slack/storage/*
+    path: /%user_home%/Library/"Application Support"/Slack/storage
     exclude_nologin_users: true
 
 # References:

--- a/artifacts/files/applications/whatsapp.yaml
+++ b/artifacts/files/applications/whatsapp.yaml
@@ -4,13 +4,13 @@ artifacts:
     description: Collect WhatsApp cache files.
     supported_os: [macos]
     collector: file
-    path: /%user_home%/Library/"Application Support"/WhatsApp/Cache/*
+    path: /%user_home%/Library/"Application Support"/WhatsApp/Cache
     exclude_nologin_users: true
   -
     description: Collect WhatsApp leveldb files.
     supported_os: [macos]
     collector: file
-    path: /%user_home%/Library/"Application Support"/WhatsApp/"Local Storage"/leveldb/*
+    path: /%user_home%/Library/"Application Support"/WhatsApp/"Local Storage"/leveldb
     exclude_nologin_users: true
 
 # WhatsApp is a cloud-based application. All chats are in the cloud. In part, chats can be found on mobile devices.

--- a/artifacts/files/logs/additional_logs.yaml
+++ b/artifacts/files/logs/additional_logs.yaml
@@ -4,7 +4,7 @@ artifacts:
     description: Collect all log files and directories.
     supported_os: [all]
     collector: file
-    path: /*
+    path: /
     name_pattern: ["*.[Ll][Oo][Gg]", "*.[Ll][Oo][Gg].*", "[Ll][Oo][Gg]", "[Ll][Oo][Gg][Ss]"]
     max_file_size: 1073741824 # 1GB
   

--- a/artifacts/files/logs/macos.yaml
+++ b/artifacts/files/logs/macos.yaml
@@ -10,12 +10,12 @@ artifacts:
     description: Collect system logs.
     supported_os: [macos]
     collector: file
-    path: /Library/Logs/*
+    path: /Library/Logs
     max_file_size: 1073741824 # 1GB
   -
     description: Collect user applications logs.
     supported_os: [macos]
     collector: file
-    path: /%user_home%/Library/Logs/*
+    path: /%user_home%/Library/Logs
     max_file_size: 1073741824 # 1GB
   

--- a/artifacts/files/logs/netscaler.yaml
+++ b/artifacts/files/logs/netscaler.yaml
@@ -4,17 +4,17 @@ artifacts:
     description: Collect nslog logs.
     supported_os: [netscaler]
     collector: file
-    path: /var/nslog/*
+    path: /var/nslog
     max_file_size: 1073741824 # 1GB
   -
     description: Collect nsproflog logs.
     supported_os: [netscaler]
     collector: file
-    path: /var/nsproflog/*
+    path: /var/nsproflog
     max_file_size: 1073741824 # 1GB
   -
     description: Collect nssynclog logs.
     supported_os: [netscaler]
     collector: file
-    path: /var/nssynclog/*
+    path: /var/nssynclog
     max_file_size: 1073741824 # 1GB

--- a/artifacts/files/logs/tomcat.yaml
+++ b/artifacts/files/logs/tomcat.yaml
@@ -4,6 +4,6 @@ artifacts:
     description: Collect Apache Tomcat logs.
     supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
     collector: file
-    path: /*
+    path: /
     name_pattern: ["access_log*", "error_log*", "httpd-access.log*", "httpd-error.log*", "catalina.out"]
     max_file_size: 1073741824 # 1GB

--- a/artifacts/files/logs/var_adm.yaml
+++ b/artifacts/files/logs/var_adm.yaml
@@ -4,5 +4,5 @@ artifacts:
     description: Collect /var/adm logs.
     supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
     collector: file
-    path: /var/adm/*
+    path: /var/adm
     max_file_size: 1073741824 # 1GB

--- a/artifacts/files/logs/var_log.yaml
+++ b/artifacts/files/logs/var_log.yaml
@@ -4,11 +4,11 @@ artifacts:
     description: Collect /var/log logs.
     supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
     collector: file
-    path: /var/log/*
+    path: /var/log
     max_file_size: 1073741824 # 1GB
   -
     description: Collect /private/var/log logs.
     supported_os: [macos]
     collector: file
-    path: /private/var/log/*
+    path: /private/var/log
     max_file_size: 1073741824 # 1GB

--- a/artifacts/files/logs/var_run_log.yaml
+++ b/artifacts/files/logs/var_run_log.yaml
@@ -4,6 +4,6 @@ artifacts:
     description: Collect /var/run/log logs.
     supported_os: [esxi]
     collector: file
-    path: /var/run/log/*
+    path: /var/run/log
     max_file_size: 1073741824 # 1GB
   

--- a/artifacts/files/system/autoruns.yaml
+++ b/artifacts/files/system/autoruns.yaml
@@ -4,35 +4,35 @@ artifacts:
     description: Collect Startup Items configuration files.
     supported_os: [macos]
     collector: file
-    path: /Library/StartupItems/*
+    path: /Library/StartupItems
     ignore_date_range: true
   -
     description: Collect Agents configuration files.
     supported_os: [macos]
     collector: file
-    path: /Library/LaunchAgents/*
+    path: /Library/LaunchAgents
     ignore_date_range: true
   -
     description: Collect Agents configuration files.
     supported_os: [macos]
     collector: file
-    path: /System/Library/LaunchAgents/*
+    path: /System/Library/LaunchAgents
     ignore_date_range: true
   -
     description: Collect Agents configuration files.
     supported_os: [macos]
     collector: file
-    path: /%user_home%/Library/LaunchAgents/*
+    path: /%user_home%/Library/LaunchAgents
     ignore_date_range: true
   -
     description: Collect Daemons configuration files.
     supported_os: [macos]
     collector: file
-    path: /Library/LaunchDaemons/*
+    path: /Library/LaunchDaemons
     ignore_date_range: true
   -
     description: Collect Daemons configuration files.
     supported_os: [macos]
     collector: file
-    path: /System/Library/LaunchDaemons/*
+    path: /System/Library/LaunchDaemons
     ignore_date_range: true

--- a/artifacts/files/system/etc.yaml
+++ b/artifacts/files/system/etc.yaml
@@ -4,12 +4,12 @@ artifacts:
     description: Collect system configuration files.
     supported_os: [all]
     collector: file
-    path: /etc/*
+    path: /etc
     exclude_name_pattern: ["shadow", "shadow-"]
     ignore_date_range: true
   -
     description: Collect system configuration files.
     supported_os: [macos]
     collector: file
-    path: /private/etc/*
+    path: /private/etc
     ignore_date_range: true

--- a/artifacts/files/system/job_scheduler.yaml
+++ b/artifacts/files/system/job_scheduler.yaml
@@ -4,24 +4,24 @@ artifacts:
     description: Collect cron files.
     supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
     collector: file
-    path: /var/cron/*
+    path: /var/cron
   -
     description: Collect cron files.
     supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
     collector: file
-    path: /var/adm/cron/*
+    path: /var/adm/cron
   -
     description: Collect at files.
     supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
     collector: file
-    path: /var/spool/at/*
+    path: /var/spool/at
   -
     description: Collect at files.
     supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
     collector: file
-    path: /var/spool/cron/*
+    path: /var/spool/cron
   -
     description: Collect at files.
     supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
     collector: file
-    path: /private/var/at/tabs/*
+    path: /private/var/at/tabs

--- a/artifacts/files/system/macos_mru.yaml
+++ b/artifacts/files/system/macos_mru.yaml
@@ -12,14 +12,14 @@ artifacts:
     description: Collect macOS Most Recently Used.
     supported_os: [macos]
     collector: file
-    path: /%user_home%/Library/"Application Support"/com.apple.sharedfilelist/*
+    path: /%user_home%/Library/"Application Support"/com.apple.sharedfilelist
     ignore_date_range: true
     exclude_nologin_users: true
   -
     description: Collect macOS Most Recently Used.
     supported_os: [macos]
     collector: file
-    path: /%user_home%/Library/"Application Support"/com.apple.spotlight.Shortcuts/*
+    path: /%user_home%/Library/"Application Support"/com.apple.spotlight.Shortcuts
     ignore_date_range: true
     exclude_nologin_users: true
   -

--- a/artifacts/files/system/networkmanager.yaml
+++ b/artifacts/files/system/networkmanager.yaml
@@ -4,5 +4,5 @@ artifacts:
     description: Collect Network Manager files.
     supported_os: [linux]
     collector: file
-    path: /var/lib/NetworkManager/*
+    path: /var/lib/NetworkManager
     ignore_date_range: true

--- a/artifacts/files/system/nsconfig.yaml
+++ b/artifacts/files/system/nsconfig.yaml
@@ -4,5 +4,5 @@ artifacts:
     description: Collect system configuration files.
     supported_os: [netscaler]
     collector: file
-    path: /flash/nsconfig/*
+    path: /flash/nsconfig
     ignore_date_range: true

--- a/artifacts/files/system/startup_items.yaml
+++ b/artifacts/files/system/startup_items.yaml
@@ -4,35 +4,35 @@ artifacts:
     description: Collect Startup Items configuration files.
     supported_os: [macos]
     collector: file
-    path: /Library/StartupItems/*
+    path: /Library/StartupItems
     ignore_date_range: true
   -
     description: Collect Agents configuration files.
     supported_os: [macos]
     collector: file
-    path: /Library/LaunchAgents/*
+    path: /Library/LaunchAgents
     ignore_date_range: true
   -
     description: Collect Agents configuration files.
     supported_os: [macos]
     collector: file
-    path: /System/Library/LaunchAgents/*
+    path: /System/Library/LaunchAgents
     ignore_date_range: true
   -
     description: Collect Agents configuration files.
     supported_os: [macos]
     collector: file
-    path: /%user_home%/Library/LaunchAgents/*
+    path: /%user_home%/Library/LaunchAgents
     ignore_date_range: true
   -
     description: Collect Daemons configuration files.
     supported_os: [macos]
     collector: file
-    path: /Library/LaunchDaemons/*
+    path: /Library/LaunchDaemons
     ignore_date_range: true
   -
     description: Collect Daemons configuration files.
     supported_os: [macos]
     collector: file
-    path: /System/Library/LaunchDaemons/*
+    path: /System/Library/LaunchDaemons
     ignore_date_range: true

--- a/artifacts/files/system/systemd.yaml
+++ b/artifacts/files/system/systemd.yaml
@@ -4,11 +4,11 @@ artifacts:
     description: Collect systemd configuration files.
     supported_os: [linux]
     collector: file
-    path: /lib/systemd/system/*
+    path: /lib/systemd/system
     ignore_date_range: true
   -
     description: Collect systemd configuration files.
     supported_os: [linux]
     collector: file
-    path: /usr/lib/systemd/system/*
+    path: /usr/lib/systemd/system
     ignore_date_range: true

--- a/artifacts/files/system/var_spool.yaml
+++ b/artifacts/files/system/var_spool.yaml
@@ -4,9 +4,9 @@ artifacts:
     description: Collect spool files.
     supported_os: [all]
     collector: file
-    path: /var/spool/*
+    path: /var/spool
   -
     description: Collect spool files.
     supported_os: [macos]
     collector: file
-    path: /private/var/spool/*
+    path: /private/var/spool

--- a/artifacts/hash_executables/hash_executables.yaml
+++ b/artifacts/hash_executables/hash_executables.yaml
@@ -4,7 +4,7 @@ artifacts:
     description: Find files that contain at least +x flag set for other.
     supported_os: [all]
     collector: find
-    path: /*
+    path: /
     exclude_file_system: [proc, procfs]
     file_type: f
     max_depth: 4
@@ -15,7 +15,7 @@ artifacts:
     description: Find files that contain at least +x flag set for group.
     supported_os: [all]
     collector: find
-    path: /*
+    path: /
     exclude_file_system: [proc, procfs]
     file_type: f
     max_depth: 4
@@ -26,7 +26,7 @@ artifacts:
     description: Find files that contain at least +x flag set for owner.
     supported_os: [all]
     collector: find
-    path: /*
+    path: /
     exclude_file_system: [proc, procfs]
     file_type: f
     max_depth: 4

--- a/artifacts/live_response/system/suid_sgid.yaml
+++ b/artifacts/live_response/system/suid_sgid.yaml
@@ -4,7 +4,7 @@ artifacts:
     description: Search for files that have SUID bit set.
     supported_os: [all]
     collector: find
-    path: /*
+    path: /
     exclude_file_system: [proc, procfs]
     file_type: f
     max_depth: 5
@@ -14,7 +14,7 @@ artifacts:
     description: Search for files that have SGID bit set.
     supported_os: [all]
     collector: find
-    path: /*
+    path: /
     exclude_file_system: [proc, procfs]
     file_type: f
     max_depth: 5


### PR DESCRIPTION
Removing /* from path enables UAC to find hidden files as well.

Signed-off-by: Thiago Canozzo Lahr <tclahr@br.ibm.com>