### PR TITLE
refactor: exit true to 'date' command

### DIFF
--- a/.github/workflows/deploy-vm-and-run-tests.yaml
+++ b/.github/workflows/deploy-vm-and-run-tests.yaml
@@ -100,7 +100,7 @@ jobs:
         run: vagrant upload uac-unit-test uac-unit-test
 
       - name: Run date
-        run: vagrant ssh -c "date"
+        run: vagrant ssh -c "date || true"
 
       - name: Run uname -a
         run: vagrant ssh -c "uname -a"


### PR DESCRIPTION
'date' command fails on OpenWrt, so a || true was added after the
command.

Signed-off-by: Thiago Canozzo Lahr <tclahr@br.ibm.com>