### PR TITLE
feat: add azure storage transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## DEVELOPMENT VERSION
 
+### New Features
+
+- Added '--azure-storage-sas-url' switch which allows for pushing the output file to Azure Storage using shared access signature (SAS) URLs (if curl available) ([#62](https://github.com/tclahr/uac/issues/62)).
+- Added '--azure-storage-sas-url-log-file' switch which allows for pushing the output log file to Azure Storage using shared access signature (SAS) URLs (if curl available) ([#62](https://github.com/tclahr/uac/issues/62)).
+
 ### New Artifacts
 
 - New artifact that collects the status of firewall and ufw managed rules (live_response/network/ufw.yaml).

--- a/lib/azure_storage_sas_url_transfer.sh
+++ b/lib/azure_storage_sas_url_transfer.sh
@@ -1,0 +1,45 @@
+# Copyright (C) 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the “License”);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+###############################################################################
+# Transfer file to Azure Storage SAS URL.
+# Globals:
+#   None
+# Requires:
+#   None
+# Arguments:
+#   $1: source file
+#   $2: Azure Storage SAS URL
+# Outputs:
+#   None.
+# Exit Status:
+#   Exit with status 0 on success.
+#   Exit with status greater than 0 if errors occur.
+###############################################################################
+azure_storage_sas_url_transfer()
+{
+  au_source="${1:-}"
+  au_azure_storage_sas_url="${2:-}"
+
+  curl \
+    --fail \
+    --request PUT \
+    --header "x-ms-blob-type: BlockBlob" \
+    --header "Content-Type: application/octet-stream" \
+    --header "Accept: */*" \
+    --header "Expect: 100-continue" \
+    --upload-file "${au_source}" \
+    "${au_azure_storage_sas_url}"
+
+}

--- a/lib/azure_storage_sas_url_transfer_test.sh
+++ b/lib/azure_storage_sas_url_transfer_test.sh
@@ -1,0 +1,43 @@
+# Copyright (C) 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the “License”);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+###############################################################################
+# Test the connectivity to Azure Storage SAS URL.
+# Globals:
+#   None
+# Requires:
+#   None
+# Arguments:
+#   $1: Azure Storage SAS URL
+# Outputs:
+#   None.
+# Exit Status:
+#   Exit with status 0 on success.
+#   Exit with status greater than 0 if errors occur.
+###############################################################################
+azure_storage_sas_url_transfer_test()
+{
+  ab_azure_storage_sas_url="${1:-}"
+
+  curl \
+    --fail \
+    --request PUT \
+    --header "x-ms-blob-type: BlockBlob" \
+    --header "Content-Type: application/text" \
+    --header "Accept: */*" \
+    --header "Expect: 100-continue" \
+    --data "Transfer test from UAC" \
+    "${ab_azure_storage_sas_url}"
+
+}

--- a/lib/usage.sh
+++ b/lib/usage.sh
@@ -110,6 +110,10 @@ Remote Transfer Arguments:
                     Transfer output file to AWS S3 using a pre-signed URL.
       --s3-presigned-url-log-file URL
                     Transfer log file to AWS S3 using a pre-signed URL.
+      --azure-storage-sas-url URL
+                    Transfer output file to Azure Storage using a SAS URL.
+      --azure-storage-sas-url-log-file URL
+                    Transfer log file to Azure Storage using a SAS URL.
       --delete-local-on-successful-transfer
                     Delete local output and log files on successful transfer.
 

--- a/uac
+++ b/uac
@@ -50,6 +50,8 @@ export PATH
 . "${UAC_DIR}/lib/archive_compress_data.sh"
 . "${UAC_DIR}/lib/archive_data.sh"
 . "${UAC_DIR}/lib/array_to_list.sh"
+. "${UAC_DIR}/lib/azure_storage_sas_url_transfer_test.sh"
+. "${UAC_DIR}/lib/azure_storage_sas_url_transfer.sh"
 . "${UAC_DIR}/lib/check_available_system_tools.sh"
 . "${UAC_DIR}/lib/command_collector.sh"
 . "${UAC_DIR}/lib/copy_data.sh"
@@ -126,6 +128,8 @@ ua_sftp_port=""
 ua_sftp_identity_file=""
 ua_s3_presigned_url=""
 ua_s3_presigned_url_log_file=""
+ua_azure_storage_sas_url=""
+ua_azure_storage_sas_url_log_file=""
 ua_delete_local_on_successful_transfer=false
 ua_debug_mode=false
 ua_temp_data_dir_symlink_support=false
@@ -370,6 +374,26 @@ Try 'uac --help' for more information.\n" >&2
         exit 1
       fi
       ;;
+      "--azure-storage-sas-url")
+      if [ -n "${2}" ]; then
+        ua_azure_storage_sas_url="${2}"
+        shift
+      else
+        printf %b "uac: option '${1}' requires an argument.\n\
+Try 'uac --help' for more information.\n" >&2
+        exit 1
+      fi
+      ;;
+    "--azure-storage-sas-url-log-file")
+      if [ -n "${2}" ]; then
+        ua_azure_storage_sas_url_log_file="${2}"
+        shift
+      else
+        printf %b "uac: option '${1}' requires an argument.\n\
+Try 'uac --help' for more information.\n" >&2
+        exit 1
+      fi
+      ;;
     "--delete-local-on-successful-transfer")
       ua_delete_local_on_successful_transfer=true
       ;;
@@ -549,7 +573,7 @@ if [ -n "${ua_sftp_destination}" ]; then
   fi
 fi
 
-# test the connectivity to s3 presigned url
+# test the connectivity to S3 presigned url
 if [ -n "${ua_s3_presigned_url}" ]; then
   if eval "curl --version" >/dev/null 2>/dev/null; then
     if s3_presigned_url_transfer_test "${ua_s3_presigned_url}"; then
@@ -559,6 +583,21 @@ if [ -n "${ua_s3_presigned_url}" ]; then
     fi
   else
     printf %b "uac: cannot transfer to S3 presigned URL because 'curl' \
+tool was not found.\n"
+    exit 1
+  fi
+fi
+
+# test the connectivity to Azure Blob Storage SAS url
+if [ -n "${ua_azure_storage_sas_url}" ]; then
+  if eval "curl --version" >/dev/null 2>/dev/null; then
+    if azure_storage_sas_url_transfer_test "${ua_azure_storage_sas_url}"; then
+      true
+    else
+      exit 1
+    fi
+  else
+    printf %b "uac: cannot transfer to Azure Blob Storage SAS URL because 'curl' \
 tool was not found.\n"
     exit 1
   fi
@@ -894,7 +933,7 @@ if [ -f "${ua_destination_dir}/${ua_output_name}" ] \
   fi
 fi
 
-# transfer output and log file to s3 presigned url
+# transfer output and log file to S3 presigned url
 if [ -f "${ua_destination_dir}/${ua_output_name}" ]; then
   if [ -n "${ua_s3_presigned_url}" ]; then
     printf %b "Transferring output file to S3 presigned URL. Please wait...\n"
@@ -918,6 +957,36 @@ if [ -f "${ua_destination_dir}/${ua_output_name}" ]; then
           && rm -f "${ua_destination_dir}/${ua_acquisition_log}" 2>/dev/null
       else
         printf %b "Could not transfer log file to S3 presigned URL\n"
+        exit 1
+      fi
+    fi
+  fi
+fi
+
+# transfer output and log file to Azure Storage SAS url
+if [ -f "${ua_destination_dir}/${ua_output_name}" ]; then
+  if [ -n "${ua_azure_storage_sas_url}" ]; then
+    printf %b "Transferring output file to Azure Storage SAS URL. Please wait...\n"
+    if azure_storage_sas_url_transfer "${ua_destination_dir}/${ua_output_name}" \
+      "${ua_azure_storage_sas_url}"; then
+      printf %b "File transferred successfully\n"
+      # delete output file on success transfer
+      ${ua_delete_local_on_successful_transfer} \
+        && rm -f "${ua_destination_dir}/${ua_output_name}" 2>/dev/null
+    else
+      printf %b "Could not transfer output file to Azure Storage SAS URL\n"
+      exit 1
+    fi
+    if [ -n "${ua_azure_storage_sas_url_log_file}" ]; then
+      printf %b "Transferring log file to Azure Storage SAS URL. Please wait...\n"
+      if azure_storage_sas_url_transfer "${ua_destination_dir}/${ua_acquisition_log}" \
+        "${ua_azure_storage_sas_url_log_file}"; then
+        printf %b "File transferred successfully\n"
+        # delete output file on success transfer
+        ${ua_delete_local_on_successful_transfer} \
+          && rm -f "${ua_destination_dir}/${ua_acquisition_log}" 2>/dev/null
+      else
+        printf %b "Could not transfer log file to Azure Storage SAS URL\n"
         exit 1
       fi
     fi


### PR DESCRIPTION
Added '--azure-storage-sas-url' switch which allows for pushing the output file to Azure Storage using shared access signature (SAS) URLs.

Added '--azure-storage-sas-url-log-file' switch which allows for pushing the output log file to Azure Storage using shared access signature (SAS) URLs.

Issue (#62)

Signed-off-by: Thiago Canozzo Lahr <tclahr@br.ibm.com>