### PR TITLE
refactor: remove /private from macos path

### DIFF
--- a/artifacts/files/logs/macos_unified_logs.yaml
+++ b/artifacts/files/logs/macos_unified_logs.yaml
@@ -4,16 +4,16 @@ artifacts:
     description: Collect macOS Unified Logs tracev3 files.
     supported_os: [macos]
     collector: file
-    path: /private/var/db/diagnostics
+    path: /var/db/diagnostics
     name_pattern: ["*.tracev3"]
   -
     description: Collect macOS Unified Logs UUID files.
     supported_os: [macos]
     collector: file
-    path: /private/var/db/uuidtext
+    path: /var/db/uuidtext
   -
     description: Collect macOS Unified Logs timesync files.
     supported_os: [macos]
     collector: file
-    path: /private/var/db/diagnostics/Timesync
+    path: /var/db/diagnostics/Timesync
   

--- a/artifacts/files/logs/var_log.yaml
+++ b/artifacts/files/logs/var_log.yaml
@@ -1,14 +1,8 @@
-version: 1.0
+version: 2.0
 artifacts:
   -
     description: Collect /var/log logs.
     supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
     collector: file
     path: /var/log
-    max_file_size: 1073741824 # 1GB
-  -
-    description: Collect /private/var/log logs.
-    supported_os: [macos]
-    collector: file
-    path: /private/var/log
     max_file_size: 1073741824 # 1GB

--- a/artifacts/files/system/etc.yaml
+++ b/artifacts/files/system/etc.yaml
@@ -1,4 +1,4 @@
-version: 1.0
+version: 2.0
 artifacts:
   -
     description: Collect system configuration files.
@@ -6,10 +6,4 @@ artifacts:
     collector: file
     path: /etc
     exclude_name_pattern: ["shadow", "shadow-"]
-    ignore_date_range: true
-  -
-    description: Collect system configuration files.
-    supported_os: [macos]
-    collector: file
-    path: /private/etc
     ignore_date_range: true

--- a/artifacts/files/system/job_scheduler.yaml
+++ b/artifacts/files/system/job_scheduler.yaml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 3.0
 artifacts:
   -
     description: Collect cron files.
@@ -24,7 +24,7 @@ artifacts:
     description: Collect at files.
     supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
     collector: file
-    path: /private/var/at/tabs
+    path: /var/at/tabs
   -
     description: Collect cron files.
     supported_os: [macos]

--- a/artifacts/files/system/knowledgec.yaml
+++ b/artifacts/files/system/knowledgec.yaml
@@ -1,10 +1,10 @@
-version: 1.0
+version: 2.0
 artifacts:
   -
     description: Collect knowledgeC database file.
     supported_os: [macos]
     collector: file
-    path: /private/var/db/CoreDuet/Knowledge/knowledgeC.db
+    path: /var/db/CoreDuet/Knowledge/knowledgeC.db
     ignore_date_range: true
   -
     description: Collect knowledgeC database file.

--- a/artifacts/files/system/network_application_usage.yaml
+++ b/artifacts/files/system/network_application_usage.yaml
@@ -1,13 +1,13 @@
-version: 1.0
+version: 2.0
 artifacts:
   -
     description: Collect netusage.sqlite database file. Network Usage Application Data contains information about how an application sends or receives data over the network.
     supported_os: [macos]
     collector: file
-    path: /private/var/networkd/db/netusage.sqlite
+    path: /var/networkd/db/netusage.sqlite
   -
     description: Collect DataUsage.sqlite database file. Network Usage Application Data contains information about how an application sends or receives data over the network.
     supported_os: [macos]
     collector: file
-    path: /private/var/wireless/Library/Databases/DataUsage.sqlite
+    path: /var/wireless/Library/Databases/DataUsage.sqlite
   

--- a/artifacts/files/system/powerlog.yaml
+++ b/artifacts/files/system/powerlog.yaml
@@ -4,6 +4,6 @@ artifacts:
     description: Collect Powerlog files.
     supported_os: [macos]
     collector: file
-    path: /private/var/db/powerlog/Library/BatteryLife/CurrentPowerlog.PLSQL*
+    path: /var/db/powerlog/Library/BatteryLife/CurrentPowerlog.PLSQL*
     ignore_date_range: true
   

--- a/artifacts/files/system/private_tmp.yaml
+++ b/artifacts/files/system/private_tmp.yaml
@@ -1,9 +1,0 @@
-version: 1.0
-artifacts:
-  -
-    description: Collect system temporary files.
-    supported_os: [macos]
-    collector: file
-    path: /private/tmp
-    file_type: f
-    max_file_size: 5242880 # 5MB

--- a/artifacts/files/system/startup_items.yaml
+++ b/artifacts/files/system/startup_items.yaml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 3.0
 artifacts:
   -
     description: Collect Startup Items configuration files.
@@ -40,6 +40,6 @@ artifacts:
     description: Collect login items installed using the Service Management framework.
     supported_os: [macos]
     collector: file
-    path: /private/var/db/com.apple.xpc.launchd
+    path: /var/db/com.apple.xpc.launchd
     name_pattern: ["loginitems.*.plist"]
     ignore_date_range: true

--- a/artifacts/files/system/var_spool.yaml
+++ b/artifacts/files/system/var_spool.yaml
@@ -1,12 +1,7 @@
-version: 1.0
+version: 2.0
 artifacts:
   -
     description: Collect spool files.
     supported_os: [all]
     collector: file
     path: /var/spool
-  -
-    description: Collect spool files.
-    supported_os: [macos]
-    collector: file
-    path: /private/var/spool


### PR DESCRIPTION
Remove /private prefix so /private/var, /private/etc and /private/tmp are collected via /var, /etc and /tmp as any other OS.

Signed-off-by: Thiago Canozzo Lahr <tclahr@br.ibm.com>