### PR TITLE
Added artifacts/files/system/netscaler.yaml

### DIFF
--- a/artifacts/files/system/netscaler.yaml
+++ b/artifacts/files/system/netscaler.yaml
@@ -1,0 +1,26 @@
+version: 1.0
+artifacts:
+  -
+    description: Collect files from /var/vpn
+    supported_os: [netscaler]
+    collector: file
+    path: /var/vpn
+    max_file_size: 5242880 # 5 MB
+  -
+    description: Collect files from /var/netscaler/logon
+    supported_os: [netscaler]
+    collector: file
+    path: /var/netscaler/logon
+    max_file_size: 5242880 # 5 MB
+  -
+    description: Collect files from /var/python
+    supported_os: [netscaler]
+    collector: file
+    path: /var/python
+    max_file_size: 5242880 # 5 MB
+  -
+    description: Collect files from /netscaler/ns_gui
+    supported_os: [netscaler]
+    collector: file
+    path: /netscaler/ns_gui
+    max_file_size: 5242880 # 5 MB


### PR DESCRIPTION
Hello,

This is a submission for the collection of additional files on Citrix NetScaler gateways.

The `artifacts/files/system/netscaler.yaml` artifact allows to collect files under the following directories and subdirectories:

- /netscaler/ns_gui
- /var/netscaler/logon
- /var/python
- /var/vpn


According to publicly available information (some references are listed hereafter), webshells have been found on compromised gateways in the aforementioned directories:


- [Exploitation of Citrix Zero-Day by Possible Espionage Actors (CVE-2023-3519)](https://www.mandiant.com/resources/blog/citrix-zero-day-espionage)
- [Threat Actors Exploiting Citrix CVE-2023-3519 to Implant Webshells](https://www.cisa.gov/news-events/cybersecurity-advisories/aa23-201a)
- [Checklist for NetScaler (Citrix ADC) CVE-2023-3519](https://www.deyda.net/index.php/en/2023/07/19/checklist-for-citrix-adc-cve-2023-3519/)


Best regards.