### PR TITLE
exclude BSD password files

### DIFF
--- a/artifacts/files/system/etc.yaml
+++ b/artifacts/files/system/etc.yaml
@@ -5,7 +5,7 @@ artifacts:
     supported_os: [aix, android, esxi, freebsd, linux, netbsd, netscaler, openbsd, solaris]
     collector: file
     path: /etc
-    exclude_name_pattern: ["shadow", "shadow-"]
+    exclude_name_pattern: ["shadow", "shadow-", "master.passwd", "spwd.db"]
     ignore_date_range: true
   -
     description: Collect system configuration files.


### PR DESCRIPTION
Hi,

I interpret following code (the files named in "exclude_name_pattern") that you want to not include password information from the local system in the collected dataset:

https://github.com/tclahr/uac/blob/ff47553d9acab3e3012c003585d37177361ce7bd/artifacts/files/system/etc.yaml#L4-L9

This does not work for BSD-based operating systems (OpenBSD, FreeBSD, NetBSD, etc.). For those OSs, the files `/etc/master.passwd` and `/etc/spwd.db` contain the hashed passwords of local users. I added the two files to the code.

I executed UAC with the changes on an OpenBSD machine and the two files in question were excluded. I did not check for any side-effect with the other artifacts.