### PR TITLE
exclude group shadow files for Linux

### DIFF
--- a/artifacts/files/system/etc.yaml
+++ b/artifacts/files/system/etc.yaml
@@ -5,7 +5,7 @@ artifacts:
     supported_os: [aix, android, esxi, freebsd, linux, netbsd, netscaler, openbsd, solaris]
     collector: file
     path: /etc
-    exclude_name_pattern: ["shadow", "shadow-", "master.passwd", "spwd.db"]
+    exclude_name_pattern: ["shadow", "shadow-", "master.passwd", "spwd.db", "gshadow", "gshadow-"]
     ignore_date_range: true
   -
     description: Collect system configuration files.


### PR DESCRIPTION
Add exclusions for the group shadow files on Linux. Those files contain password hashes for groups.

There is one think left open: BSD-derived operating systems store hashes for passwords of group accounts in `/etc/group`. That file also contains the "normal" information about groups. So excluding that file would be counter-productive, as we would lose the information about groups configured on BSD-derived OSs.  So I didn't add such exclusion here.