### PR TITLE
fix: fix custom mount point in triage archive

### DIFF
--- a/uac
+++ b/uac
@@ -776,7 +776,7 @@ if ${TAR_TOOL_AVAILABLE}; then
     sort_uniq_file "${TEMP_DATA_DIR}/.files.tmp" 2>>"${UAC_STDERR_LOG_FILE}"
     if ${ua_temp_data_dir_symlink_support}; then
       # create symbolic link to /
-      ln -s "/" "${TEMP_DATA_DIR}/[root]" 2>>"${UAC_STDERR_LOG_FILE}"
+      ln -s "${MOUNT_POINT}" "${TEMP_DATA_DIR}/[root]" 2>>"${UAC_STDERR_LOG_FILE}"
     else
       # copy files to uac-data.tmp/[root]
       printf %b "Copying files to ${TEMP_DATA_DIR}/[root]. Please wait...\n"
@@ -785,7 +785,7 @@ if ${TAR_TOOL_AVAILABLE}; then
     fi
     # add [root] string to the beginning of each entry in .files.tmp
     # and add them to the list of files to be archived within the output file
-    sed -e 's:^/:\[root\]/:' "${TEMP_DATA_DIR}/.files.tmp" \
+    sed -e "s:^${MOUNT_POINT%/}/:\[root\]/:" "${TEMP_DATA_DIR}/.files.tmp" \
       >>"${TEMP_DATA_DIR}/.output_file.tmp"
   fi
 


### PR DESCRIPTION
previous behavior: non standard mount point is part of the triage file structure

e.g. offline disk image mount point path is part of the triage file structure

current behavior: the custom point is not displayed in the triage archive structure