### PR TITLE
Adding support for collecting nftables ruleset

### DIFF
--- a/artifacts/live_response/network/nft.yaml
+++ b/artifacts/live_response/network/nft.yaml
@@ -1,0 +1,8 @@
+version: 1.0
+artifacts:
+  -
+    description: Collect complete nftables ruleset.
+    supported_os: [linux]
+    collector: command
+    command: nft list ruleset
+    output_file: nft_list_ruleset.txt


### PR DESCRIPTION
Newer Linux versions ship with NFtables (nft) instead of iptables.

Adding the nft.yaml to be able to fetch the complete ruleset. 