### PR TITLE
artif: get nftables ruleset if nft used instead of iptables

### DIFF
--- a/artifacts/live_response/network/nft.yaml
+++ b/artifacts/live_response/network/nft.yaml
@@ -1,0 +1,8 @@
+version: 1.0
+artifacts:
+  -
+    description: Collect complete nftables ruleset.
+    supported_os: [linux]
+    collector: command
+    command: nft list ruleset
+    output_file: nft_list_ruleset.txt


### PR DESCRIPTION
Newer versions of Linux / newer distributions use nftables by default instead of iptables.
Added this artifact collector for the nftables ruleset.