### PR TITLE
gui shortcut files of users

### DIFF
--- a/artifacts/files/system/desktop.yaml
+++ b/artifacts/files/system/desktop.yaml
@@ -1,0 +1,10 @@
+version: 1.0
+artifacts:
+  -
+    description: Collect GUI shortcut files of users.
+    supported_os: [linux, freebsd, openbsd, netbsd]
+    collector: file
+    path: /%user_home%
+    name_pattern: ["*.desktop"]
+    ignore_date_range: true
+    exclude_nologin_users: true


### PR DESCRIPTION
while playing around with detecting use of linpeas, I stumbled upon desktop shortcut files (stored e. g. under `~/.local/share/RecentDocuments/` )

one example of its content:  
```
user@system:~/.local/share/RecentDocuments$ cat linpeas_linux_amd64.desktop 
[Desktop Entry]
Icon=application-x-executable
Name=linpeas_linux_amd64
Type=Link
URL[$e]=file:$HOME/Downloads/linpeas_linux_amd64
X-KDE-LastOpenedWith=
```
_(file downloaded via browser and Download folder opened via Browser popup)_

I didn't directly find much documentation on them, but they seem to be a kind of shortcut and standardizes by freedesktop / XDG ( https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html ).  

They are bound to the system being used with a (modern) GUI.
I stumbled on it, because one of the files pointed me to a linpeas binary which I had downloaded via browser. 
They appear to be removed when the file that its pointing to does not exist anymore.
