### PR TITLE
move tool logs to the front of archive

### DIFF
--- a/artifacts/live_response/packages/pisi.yaml
+++ b/artifacts/live_response/packages/pisi.yaml
@@ -1,8 +1,0 @@
-version: 1.0
-artifacts:
-  -
-    description: Display installed packages.
-    supported_os: [linux]
-    collector: command
-    command: pisi list
-    output_file: pisi_list-installed.txt

--- a/artifacts/live_response/packages/pisi.yaml
+++ b/artifacts/live_response/packages/pisi.yaml
@@ -1,0 +1,8 @@
+version: 1.0
+artifacts:
+  -
+    description: Display installed packages.
+    supported_os: [linux]
+    collector: command
+    command: pisi list
+    output_file: pisi_list-installed.txt

--- a/uac
+++ b/uac
@@ -778,9 +778,9 @@ ua_output_file_hash="-"
 # sort and uniq
 sort_uniq_file "${TEMP_DATA_DIR}/.output_file.tmp" 2>>"${UAC_STDERR_LOG_FILE}"
 # add uac.log to the list of files to be archived/copied within the output file
-echo "uac.log" >>"${TEMP_DATA_DIR}/.output_file.tmp"
+echo "uac.log" | cat - "${TEMP_DATA_DIR}/.output_file.tmp" >"${TEMP_DATA_DIR}/.output_file.tmp"
 # add uac.log.stderr to the list of files to be archived/copied within the output file
-echo "uac.log.stderr" >>"${TEMP_DATA_DIR}/.output_file.tmp"
+echo "uac.log.stderr" | cat - "${TEMP_DATA_DIR}/.output_file.tmp" >"${TEMP_DATA_DIR}/.output_file.tmp"
 
 # create output file
 if command_exists "tar"; then


### PR DESCRIPTION
This moves the tool's logs to the front of the tar archive rather than the tail. As tar is a stream format, having them at the tail ends up requiring that automation read the archive twice: once to gather details crucial to routing and parsing the data it contains, and once to actually parse the data.

Most solutions will likely still want to read archives twice in order to handle ones generated before this change, but at least they can terminate the first pass when they finish parsing the log file, thus minimizing waste.