### PR TITLE
Update is_valid_operating_system.sh to add z/OS or OS/390

### DIFF
--- a/lib/is_valid_operating_system.sh
+++ b/lib/is_valid_operating_system.sh
@@ -29,7 +29,8 @@ is_valid_operating_system()
     && [ "${io_operating_system}" != "netbsd" ] \
     && [ "${io_operating_system}" != "netscaler" ] \
     && [ "${io_operating_system}" != "openbsd" ] \
-    && [ "${io_operating_system}" != "solaris" ]; then
+    && [ "${io_operating_system}" != "solaris" ] \
+    && [ "${io_operating_system}" != "OS/390" ]; then
     return 2
   fi
 


### PR DESCRIPTION
Fixes:
```
 ./uac -p full /jenkins/results
uac: invalid operating system 'OS/390'. Use '-s' option to set one.
Try 'uac --help' for more information.
```