### PR TITLE
extending data collection on solaris

### DIFF
--- a/artifacts/files/logs/solaris.yaml
+++ b/artifacts/files/logs/solaris.yaml
@@ -21,3 +21,9 @@ artifacts:
     collector: file
     path: /var/svc/log
     max_file_size: 1073741824 # 1GB
+  -
+    description: Collect webui log files.
+    supported_os: [solaris]
+    collector: file
+    path: /var/webui/logs
+    max_file_size: 1073741824 # 1GB

--- a/artifacts/files/logs/solaris.yaml
+++ b/artifacts/files/logs/solaris.yaml
@@ -1,0 +1,17 @@
+version: 1.0
+artifacts:
+  -
+    description: Collect lastlog log file.
+    supported_os: [solaris]
+    collector: file
+    path: /var/share/adm/lastlog
+  -
+    description: Collect wtmpx log file.
+    supported_os: [solaris]
+    collector: file
+    path: /var/share/adm/wtmpx
+  -
+    description: Collect utmpx log file.
+    supported_os: [solaris]
+    collector: file
+    path: /system/volatile/utmpx

--- a/artifacts/files/logs/solaris.yaml
+++ b/artifacts/files/logs/solaris.yaml
@@ -15,3 +15,9 @@ artifacts:
     supported_os: [solaris]
     collector: file
     path: /system/volatile/utmpx
+  -
+    description: Collect svc log files.
+    supported_os: [solaris]
+    collector: file
+    path: /var/svc/log
+    max_file_size: 1073741824 # 1GB

--- a/artifacts/files/packages/pkg_contents.yaml
+++ b/artifacts/files/packages/pkg_contents.yaml
@@ -1,4 +1,4 @@
-version: 1.0
+version: 2.0
 artifacts:
   -
     description: Collect package table of contents files.
@@ -12,3 +12,8 @@ artifacts:
     collector: file
     path: /usr/pkg/pkgdb
     path_pattern: ["*/+CONTENTS"]
+  -
+    description: Collect package table of contents files.
+    supported_os: [solaris]
+    collector: file
+    path: /var/pkg/publisher/*/pkg

--- a/artifacts/files/system/svc.yaml
+++ b/artifacts/files/system/svc.yaml
@@ -1,0 +1,26 @@
+version: 1.0
+artifacts:
+  -
+    description: Collect svc manifest files.
+    supported_os: [solaris]
+    collector: file
+    path: /lib/svc/manifest
+    ignore_date_range: true
+  -
+    description: Collect svc manifest files.
+    supported_os: [solaris]
+    collector: file
+    path: /var/svc/manifest
+    ignore_date_range: true
+  -
+    description: Collect svc method (service start) files.
+    supported_os: [solaris]
+    collector: file
+    path: /lib/svc/method
+    ignore_date_range: true
+  -
+    description: Collect svc log files.
+    supported_os: [solaris]
+    collector: file
+    path: /var/svc/log
+    max_file_size: 1073741824 # 1GB

--- a/artifacts/files/system/svc.yaml
+++ b/artifacts/files/system/svc.yaml
@@ -18,9 +18,4 @@ artifacts:
     collector: file
     path: /lib/svc/method
     ignore_date_range: true
-  -
-    description: Collect svc log files.
-    supported_os: [solaris]
-    collector: file
-    path: /var/svc/log
-    max_file_size: 1073741824 # 1GB
+

--- a/artifacts/files/system/var_ld.yaml
+++ b/artifacts/files/system/var_ld.yaml
@@ -1,0 +1,7 @@
+version: 1.0
+artifacts:
+  -
+    description: Collect ld config files.
+    supported_os: [solaris]
+    collector: file
+    path: /var/ld

--- a/artifacts/files/system/var_ld.yaml
+++ b/artifacts/files/system/var_ld.yaml
@@ -5,3 +5,4 @@ artifacts:
     supported_os: [solaris]
     collector: file
     path: /var/ld
+    ignore_date_range: true

--- a/artifacts/live_response/packages/pkg.yaml
+++ b/artifacts/live_response/packages/pkg.yaml
@@ -1,10 +1,9 @@
-version: 1.0
+version: 2.0
 artifacts:
   -
     description: Displays information about installed packages.
-    supported_os: [freebsd]
+    supported_os: [freebsd, solaris]
     collector: command
     command: pkg info
     output_file: pkg_info.txt
-  
   


### PR DESCRIPTION
While using UAC on Solaris, I found some data was not covered yet:
+ script files that are run by services (using the service management facility of solaris)
+ config files for services (using the service management facility of solaris)
+ config files of the link-editor (ld)
+ information on installed packages
  + there is an artifact for this already, but it doesnt cover what we normally consider as packages
+ information files of installed packages (containing metadata of the package, changes to the system and checksums+metadata of files that are added by the package)
+ files around logins to the system

I also noticed that the bodyfile with a depth of 6 does not cover all files that are normally on a solaris system. E. g. the pkg content files have a depth of seven on the file system.
I did not propose a change to the depth limit, as Im unsure as to why it was introduced in the beginning.


I added artifact collection files and modified some existing ones to cover such data. I tested it successfully on a Solaris version 11.4

If needed, I can provide a uac collection archive with the new artifacts / changes for review :)