### PR TITLE
add http put upload capability

### DIFF
--- a/lib/http_put_transfer.sh
+++ b/lib/http_put_transfer.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+
+###############################################################################
+# Transfer file to HTTP PUT receiver.
+# Globals:
+#   None
+# Requires:
+#   None
+# Arguments:
+#   $1: source file
+#   $2: HTTP PUT url
+# Outputs:
+#   None.
+# Exit Status:
+#   Exit with status 0 on success.
+#   Exit with status greater than 0 if errors occur.
+###############################################################################
+http_put_transfer()
+{
+  hp_source="${1:-}"
+  hp_url="${2:-}"
+
+  curl \
+    --fail \
+    --request PUT \
+    --header "Content-Type: application/octet-stream" \
+    --header "Accept: */*" \
+    --header "Expect: 100-continue" \
+    --upload-file "${hp_source}" \
+    "${hp_url}/${hp_source}"
+
+}

--- a/lib/http_put_transfer_test.sh
+++ b/lib/http_put_transfer_test.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+
+###############################################################################
+# Test the connectivity to HTTP PUT server.
+# Globals:
+#   None
+# Requires:
+#   None
+# Arguments:
+#   $1: HTTP PUT URL
+# Outputs:
+#   None.
+# Exit Status:
+#   Exit with status 0 on success.
+#   Exit with status greater than 0 if errors occur.
+###############################################################################
+http_put_transfer_test()
+{
+  ht_url="${1:-}"
+
+  curl \
+    --fail \
+    --request PUT \
+    --header "Content-Type: application/text" \
+    --header "Accept: */*" \
+    --header "Expect: 100-continue" \
+    --data "Transfer test from UAC" \
+    "${ht_url}"
+
+}

--- a/uac
+++ b/uac
@@ -370,6 +370,26 @@ Try 'uac --help' for more information.\n" >&2
         exit 1
       fi
       ;;
+      "--http-put-url")
+      if [ -n "${2}" ]; then
+        ua_http_put_url="${2}"
+        shift
+      else
+        printf %b "uac: option '${1}' requires an argument.\n\
+Try 'uac --help' for more information.\n" >&2
+        exit 1
+      fi
+      ;;
+    "--http-put-url-log-file")
+      if [ -n "${2}" ]; then
+        ua_http_put_url_log_file="${2}"
+        shift
+      else
+        printf %b "uac: option '${1}' requires an argument.\n\
+Try 'uac --help' for more information.\n" >&2
+        exit 1
+      fi
+      ;;
     "--delete-local-on-successful-transfer")
       ua_delete_local_on_successful_transfer=true
       ;;
@@ -1001,6 +1021,36 @@ if [ -n "${ua_ibm_cos_url}" ]; then
           && rm -f "${ua_destination_dir}/${ua_acquisition_log}" 2>/dev/null
       else
         printf %b "Could not transfer log file to IBM Cloud Object Storage\n"
+        exit 1
+      fi
+    fi
+  fi
+fi
+
+# transfer output and log file to HTTP PUT service
+if [ -n "${ua_http_put_url}" ]; then
+  if [ -f "${ua_destination_dir}/${ua_output_filename}" ]; then
+    printf %b "Transferring output file to HTTP PUT server. Please wait...\n"
+    if http_put_transfer "${ua_destination_dir}/${ua_output_filename}" \
+      "${ua_http_put_url}"; then
+      printf %b "File transferred successfully\n"
+      # delete output file on success transfer
+      ${ua_delete_local_on_successful_transfer} \
+        && rm -f "${ua_destination_dir}/${ua_output_filename}" 2>/dev/null
+    else
+      printf %b "Could not transfer output file to HTTP PUT Storage\n"
+      exit 1
+    fi
+    if [ -n "${ua_http_put_url_log_file}" ]; then
+      printf %b "Transferring log file to HTTP PUT Storage. Please wait...\n"
+      if http_put_transfer "${ua_destination_dir}/${ua_acquisition_log}" \
+        "${ua_http_put_url_log_file}"; then
+        printf %b "File transferred successfully\n"
+        # delete output file on success transfer
+        ${ua_delete_local_on_successful_transfer} \
+          && rm -f "${ua_destination_dir}/${ua_acquisition_log}" 2>/dev/null
+      else
+        printf %b "Could not transfer log file to HTTP PUT storage\n"
         exit 1
       fi
     fi


### PR DESCRIPTION
An unauthenticated upload mechanism moves security concerns Elsewhere™, but if carefully implemented keeps the team from having to be in the secret-distribution business.

This is a nearly exact copy of the S3 presigned upload, with the distinction that it includes the name of the archive in the upload request (preventing having to specify a different URL per host).