### PR TITLE
Fix docker stats configuration

### DIFF
--- a/artifacts/live_response/containers/docker.yaml
+++ b/artifacts/live_response/containers/docker.yaml
@@ -96,5 +96,5 @@ artifacts:
     supported_os: [linux]
     collector: command
     foreach: docker container ps --all | sed 1d | awk '{print $1}'
-    command: docker stats %line%
+    command: docker stats --all --no-stream --no-trunc %line%
     output_file: docker_stats_%line%.txt


### PR DESCRIPTION
The previous command for the Docker artifact configuration `Display a live stream of resource usage statistics.` :

```yaml
  -
    description: Display a live stream of resource usage statistics.
    supported_os: [linux]
    collector: command
    foreach: docker container ps --all | sed 1d | awk '{print $1}'
    command: docker stats %line%
    output_file: docker_stats_%line%.txt
```

Was causing the collection tool to **freeze* (Command `docker stats %line%` opens a stream that runs indefinitely.)

Fixed by disabling stream:

```yaml
  -
    description: Display a live stream of resource usage statistics.
    supported_os: [linux]
    collector: command
    foreach: docker container ps --all | sed 1d | awk '{print $1}'
    command: docker stats --all --no-stream --no-trunc %line%
    output_file: docker_stats_%line%.txt
```