### PR TITLE
BSD related artifacts

### DIFF
--- a/artifacts/files/logs/openbsd.yaml
+++ b/artifacts/files/logs/openbsd.yaml
@@ -1,0 +1,8 @@
+version: 1.0
+artifacts:
+  -
+    description: Collect kernel relink log file.
+    supported_os: [openbsd]
+    collector: file
+    path: /usr/share/relink/kernel
+    path_pattern: ["*/relink.log"]

--- a/artifacts/files/system/acct.yaml
+++ b/artifacts/files/system/acct.yaml
@@ -1,0 +1,20 @@
+version: 1.0
+artifacts:
+  -
+    description: Collect system accounting files.
+    supported_os: [freebsd, netbsd, openbsd]
+    collector: file
+    path: /var/account/acct*
+    ignore_date_range: true
+  -
+    description: Collect system accounting user based summary file.
+    supported_os: [freebsd, netbsd, openbsd]
+    collector: file
+    path: /var/account/usracct
+    ignore_date_range: true
+  -
+    description: Collect system accounting command based summary file.
+    supported_os: [freebsd, netbsd, openbsd]
+    collector: file
+    path: /var/account/savacct
+    ignore_date_range: true

--- a/artifacts/files/system/device_db.yaml
+++ b/artifacts/files/system/device_db.yaml
@@ -1,0 +1,12 @@
+version: 1.0
+artifacts:
+  -
+    description: Collect database file used for device lookups.
+    supported_os: [openbsd]
+    collector: file
+    path: /var/run/dev.db
+  -
+    description: Collect database file used for device lookups.
+    supported_os: [netbsd]
+    collector: file
+    path: /var/run/dev.cdb

--- a/artifacts/files/system/locate_db.yaml
+++ b/artifacts/files/system/locate_db.yaml
@@ -1,0 +1,7 @@
+version: 1.0
+artifacts:
+  -
+    description: Collect database file used by locate command, representing a snapshot of the virtual file system accessible with minimal permissions.
+    supported_os: [freebsd, netbsd, openbsd]
+    collector: file
+    path: /var/db/locate.database

--- a/artifacts/files/system/security_backups.yaml
+++ b/artifacts/files/system/security_backups.yaml
@@ -1,0 +1,10 @@
+version: 1.0
+artifacts:
+  -
+    description: Collect file backups and hashes created by the integrated security script of BSDs.
+    supported_os: [freebsd, netbsd, openbsd]
+    collector: file
+    path: /var/backups
+    name_pattern: ["*.current", "*.backup", "*.current.sha256", "*.backup.sha256"]
+    exclude_name_pattern: ["master.passwd.current", "master.passwd.backup"]
+    ignore_date_range: true

--- a/artifacts/live_response/hardware/dmesg.yaml
+++ b/artifacts/live_response/hardware/dmesg.yaml
@@ -1,4 +1,4 @@
-version: 1.0
+version: 1.1
 artifacts:
   -
     description: Display the system/kernel message buffer.
@@ -6,3 +6,15 @@ artifacts:
     collector: command
     command: dmesg
     output_file: dmesg.txt
+  -
+    description: Display the console message buffer.
+    supported_os: [openbsd]
+    collector: command
+    command: dmesg -s
+    output_file: dmesg_-s.txt
+  -
+    description: Display all data from the message buffer, including syslog records and console output.
+    supported_os: [freebsd]
+    collector: command
+    command: dmesg -a
+    output_file: dmesg_-a.txt

--- a/artifacts/live_response/system/lastcomm.yaml
+++ b/artifacts/live_response/system/lastcomm.yaml
@@ -1,0 +1,16 @@
+version: 1.0
+artifacts:
+  -
+    description: Shows the last commands executed in a reverse order based on the default accounting file.
+    supported_os: [freebsd, netbsd, openbsd]
+    collector: command
+    command: lastcomm
+    output_file: lastcomm.txt
+  -
+    description: Shows the last commands executed in a reverse order from the historic accounting files.
+    supported_os: [freebsd, netbsd, openbsd]
+    collector: command
+    foreach: for acctfile in /var/account/acct.[0123]; do echo ${acctfile} | sed -e 's:/var/account/acct.::'; done
+    command: lastcomm -f /var/account/acct.%line%
+    output_file: lastcomm_%line%.txt
+


### PR DESCRIPTION
Hi, 

during research for a thesis, I identified multiple artifacts on OpenBSD yet to be covered by UAC.
These cover
* the console message buffer, containing stdout and stderr messages written during system startup (as supposed to kernel messages)
* system accounting files, covering processes that terminated on the system, allowing one to see past program executions (this is sadly deactivated by default, but quite usefull when active)
* backups of important system configuration files, created by the security script
* kernel relink log (contains information about the relinking of the kernel on boot or an error message about the failure to do so)
* device database (showing configured devices on system startup)
* locate database (snapshot of file system paths that can be queried with "locate" - can be used to compare file system structure at the time of database update against current file system structure)
* "lastcomm" live response - this program parses the system accounting files (if available) and decodes the content

Ive created collection files for them and successfully tested them. As by the man pages, some of these artifacts should also be available on NetBSD and FreeBSD. This has been reflected in the collection files, but I havent tested it on those platforms.
If needed, I can provide an example of data collected with them.

Kind Regards