### PR TITLE
Fixed deleted.yaml

### DIFF
--- a/artifacts/live_response/process/deleted.yaml
+++ b/artifacts/live_response/process/deleted.yaml
@@ -69,10 +69,9 @@ artifacts:
   -
     description: Find open files of (malicious) processes.
     supported_os: [linux]
-    collector: find
-    path: .list_open_file_descriptors.txt
-    is_file_list: true
-    file_type: f
+    collector: command
+    foreach: cat "%destination_directory%/.list_open_file_descriptors.txt"
+    command: find %line% -type f -print
     output_file: .open_file_descriptors.txt
   -
     description: Collect open files of (malicious) processes.


### PR DESCRIPTION
Fixed "Find open files of (malicious) processes." in deleted.yaml
The default deleted.yaml will be recorded the following log entry in uac.log.

```
2024-06-25 14:30:17 +0900 COMMAND find /.list_open_file_descriptors.txt  \( -path "/sys" -o -path "/proc/sys/fs/binfmt_misc" -o -path "/home/john/Downloads/src/uac" -o -path "/tmp/uac-data.tmp" \) -prune -o   -type f     -print
```

However, "/.list_open_file_descriptors.txt" never exists.
As a result, "Collecting open files of (malicious) processes" never succeeds and the following log entry will be recorded in uac.log.stderr

```
file_collector: file list does not exist: '/tmp/uac-data.tmp/live_response/process/.open_file_descriptors.txt'
```

What do you think of the following modification to "Find open files of (malicious) processes."?
However, the paths to be excluded have not been implemented.

```
    description: Find open files of (malicious) processes.
    supported_os: [linux]
    collector: command
    foreach: cat "%destination_directory%/.list_open_file_descriptors.txt"
    command: find %line% -type f -print
    output_file: .open_file_descriptors.txt
```
