### PR TITLE
FreeBSD: information on jails (FreeBSD specific containers)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - files/system/tmp.yaml: Updated to increase max_file_size to 10MB.
 - files/system/var_tmp.yaml: Updated to increase max_file_size to 10MB.
 - hash_executables/hash_executables.yaml: Updated to remove max_depth and max_file_size properties.
+- live_response/containers/jls.yaml: Added collection of jails used on FreeBSD systems [freebsd] [Herbert-Karl](https://github.com/Herbert-Karl)).
 - live_response/hardware/dmesg.yaml: Updated collection of console message bufffer [esxi, freebsd, netscaler, openbsd, solaris] [Herbert-Karl](https://github.com/Herbert-Karl)).
 - live_response/process/deleted.yaml: Collection of deleted processes will no longer use dd conv=swab. The binary file will be collected in its raw format now [linux].
 - live_response/process/deleted.yaml: Updated to fix the collection of open files of (malicious) processes [linux] [mnrkbys](https://github.com/mnrkbys)).
@@ -54,6 +55,7 @@
 - live_response/system/suid.yaml: Updated to remove max_depth limit.
 - live_response/system/world_writable_directories.yaml: Updated to remove max_depth limit.
 - live_response/system/world_writable_files.yaml: Updated to remove max_depth limit.
+- live_response/system/zoneadm.yaml: Artifact was moved to live_response/containers directory [Herbert-Karl](https://github.com/Herbert-Karl)).
 
 ### Command Line Option Changes
 

--- a/artifacts/live_response/containers/jls.yaml
+++ b/artifacts/live_response/containers/jls.yaml
@@ -1,0 +1,22 @@
+version: 1.0
+condition: command_exists "jls"
+output_directory: /live_response/containers
+artifacts:
+  -
+    description: List all jails, including dying ones
+    supported_os: [freebsd]
+    collector: command
+    command: jls -q -d
+    output_file: jls_-q_-d.txt
+  -
+    description: List all jails, including dying ones, with all parameters.
+    supported_os: [freebsd]
+    collector: command
+    command: jls -q -d -h
+    output_file: jls_-q_-d_-h.txt
+  -
+    description: List all jails, including dying ones, with all parameters with parameter names included.
+    supported_os: [freebsd]
+    collector: command
+    command: jls -q -d -n
+    output_file: jls_-q_-d_-n.txt

--- a/artifacts/live_response/containers/jls.yaml
+++ b/artifacts/live_response/containers/jls.yaml
@@ -1,4 +1,4 @@
-version: 1.0
+version: 2.0
 condition: command_exists "jls"
 output_directory: /live_response/containers
 artifacts:
@@ -20,3 +20,18 @@ artifacts:
     collector: command
     command: jls -q -d -n
     output_file: jls_-q_-d_-n.txt
+  -
+    description: Report a snapshot of the current processes in each running jail, including dying jails.
+    supported_os: [freebsd]
+    collector: command
+    foreach: jls -d jid
+    command: ps -J %line%
+    output_file: ps_-J_%line%.txt
+  -
+    description: Report a snapshot of the current processes in each running jail, including dying jails.
+    supported_os: [freebsd]
+    collector: command
+    foreach: jls -d jid
+    command: ps auxwww -J %line%
+    output_file: ps_auxwww_-J_%line%.txt
+

--- a/artifacts/live_response/containers/zoneadm.yaml
+++ b/artifacts/live_response/containers/zoneadm.yaml
@@ -1,6 +1,6 @@
 version: 2.0
 condition: command_exists "zoneadm"
-output_directory: /live_response/system
+output_directory: /live_response/containers
 artifacts:
   -
     description: Display all installed zones. A zone is an application container that is maintained by the operating system run-time.

--- a/artifacts/live_response/containers/zoneadm.yaml
+++ b/artifacts/live_response/containers/zoneadm.yaml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 3.0
 condition: command_exists "zoneadm"
 output_directory: /live_response/containers
 artifacts:


### PR DESCRIPTION
Hi,

I noticed that data on jails used on FreeBSD is not yet collected.
Ive added an artifact to list the running jails. 
I've also included separate process listings for each jail. That information is technically already covered with the normal process listing output, but it is not easily visible which processes run in jails (and even harder to identify the jail they belong to).

Ive also moved an artifact regarding Solaris Zones to the container aspect of live response, as Solaris Zones are a kind of container technology.

See https://docs.freebsd.org/en/books/handbook/jails/ for official information on FreeBSD jails