### PR TITLE
fix: zip binary segmentation fault

### DIFF
--- a/lib/get_bin_path.sh
+++ b/lib/get_bin_path.sh
@@ -61,13 +61,21 @@ _get_bin_path()
   __gb_correct_arch=`_get_system_arch_bin_path "${__gb_arch}"`
   __gb_path=""
 
-  # tools directory
-  for __gb_tool in statx zip; do
-    for __gb_dir in "${__UAC_DIR}"/tools/"${__gb_tool}"/*; do
-      if echo "${__gb_dir}" | grep -q -E "${__gb_os}"; then
+  # zip tool
+  # test whether zip can run in the target system before adding it to PATH
+  for __gb_dir in "${__UAC_DIR}"/tools/zip/*; do
+    if echo "${__gb_dir}" | grep -q -E "${__gb_os}"; then
+      if eval "${__gb_dir}/${__gb_correct_arch}/zip" - "${__UAC_DIR}/uac" >/dev/null 2>/dev/null; then
         __gb_path="${__gb_path}${__gb_path:+:}${__gb_dir}/${__gb_correct_arch}"
       fi
-    done
+    fi
+  done
+
+  # statx tool
+  for __gb_dir in "${__UAC_DIR}"/tools/statx/*; do
+    if echo "${__gb_dir}" | grep -q -E "${__gb_os}"; then
+      __gb_path="${__gb_path}${__gb_path:+:}${__gb_dir}/${__gb_correct_arch}"
+    fi
   done
 
   # bin directory

--- a/lib/is_output_format_supported.sh
+++ b/lib/is_output_format_supported.sh
@@ -24,7 +24,7 @@ _is_output_format_supported()
           __if_output_extension="tar.gz"
         fi
       else
-        _error_msg "cannot create output file as tar tool was not found. Please choose a different output format."
+        _error_msg "cannot create output file as tar is not available. Please choose a different output format."
         return 1
       fi
       ;;
@@ -35,12 +35,12 @@ _is_output_format_supported()
           if zip --password infected - "${__UAC_DIR}/uac" >/dev/null 2>/dev/null; then
             true
           else
-            _error_msg "cannot create password-protected zip file as zip tool does not support such feature"
+            _error_msg "cannot create password-protected zip file as zip does not support such feature"
             return 1
           fi
         fi  
       else
-        _error_msg "cannot create output file as zip tool was not found. Please choose a different output format."
+        _error_msg "cannot create output file as zip is not available for the target system. Please choose a different output format."
         return 1
       fi
       ;;

--- a/uac
+++ b/uac
@@ -167,6 +167,12 @@ __ua_artifact_list=`_validate_artifact_list "${__UAC_ARTIFACT_LIST}"` || _exit_f
 _verbose_msg "Loading config file..."
 _load_config_file "${__UAC_CONFIG_FILE}" || _exit_fatal
 
+# add proper local 'bin' and 'tools' directory to path
+__ua_bin_path=`_get_bin_path "${__UAC_OPERATING_SYSTEM}" "${__UAC_SYSTEM_ARCH}"`
+PATH="${__ua_bin_path}:${PATH}"
+PATH="${__UAC_DIR}/tools/date_to_epoch_pl:${__UAC_DIR}/tools/find_pl:${__UAC_DIR}/tools/stat_pl:${PATH}"
+export PATH
+
 # set tar as the default output format if none has been set via command line
 if [ -z "${__UAC_OUTPUT_FORMAT}" ]; then
   __UAC_OUTPUT_FORMAT="tar"
@@ -183,12 +189,6 @@ __UAC_OUTPUT_BASE_NAME=`echo "${__UAC_OUTPUT_BASE_NAME}" \
 __UAC_OUTPUT_BASE_NAME=`_sanitize_output_file "${__UAC_OUTPUT_BASE_NAME}"`
 
 _output_exists "${__UAC_DESTINATION_DIR}/${__UAC_OUTPUT_BASE_NAME}${__UAC_OUTPUT_EXTENSION:+.}${__UAC_OUTPUT_EXTENSION}" && _exit_fatal
-
-# add proper local 'bin' and 'tools' directory to path
-__ua_bin_path=`_get_bin_path "${__UAC_OPERATING_SYSTEM}" "${__UAC_SYSTEM_ARCH}"`
-PATH="${__ua_bin_path}:${PATH}"
-PATH="${__UAC_DIR}/tools/date_to_epoch_pl:${__UAC_DIR}/tools/find_pl:${__UAC_DIR}/tools/stat_pl:${PATH}"
-export PATH
 
 # check whether start and end dates are valid
 if [ -n "${__UAC_START_DATE}" ]; then
@@ -279,9 +279,6 @@ if [ -n "${__UAC_AZURE_STORAGE_SAS_URL}" ]; then
     "${__UAC_AZURE_STORAGE_SAS_URL}" \
     || _exit_fatal "error connecting to Azure Storage SAS URL"
 fi
-
-# use a safe umask for created files
-umask 027
 
 # check whether temp-dir exists
 if [ -n "${__UAC_TEMP_DIR}" ]; then


### PR DESCRIPTION
Update code to test whether zip can run in the target system before adding it to PATH.

zip binary was causing either a "segmentation fault" or a "kernel too old" in some specific systems making the output file creation to fail.

Fix #245