### PR TITLE
artif: update kernel_tainted_state.yaml artifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - live_response/process/strings_running_processes.yaml: Added support for collecting strings even when the strings command is unavailable. In such cases, the built-in astrings command will be used instead [all].
 - live_response/system/hidden_directories.yaml: Updated to remove max_depth limit.
 - live_response/system/hidden_files.yaml: Updated to remove max_depth limit.
+- live_response/system/kernel_tainted_state.yaml: Added collection of dmesg messages showing modules tainting the kernel [linux].
 - live_response/system/lastcomm.yaml: Added collection of the last commands executed in a reverse order based on the default and historic accounting file [freebsd, netbsd, openbsd] [Herbert-Karl](https://github.com/Herbert-Karl)).
 - live_response/system/sgid.yaml: Updated to remove max_depth limit.
 - live_response/system/socket_files.yaml: Updated to remove max_depth limit.

--- a/artifacts/live_response/system/kernel_tainted_state.yaml
+++ b/artifacts/live_response/system/kernel_tainted_state.yaml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 3.0
 output_directory: /live_response/system
 artifacts:
   -
@@ -7,6 +7,12 @@ artifacts:
     collector: command
     command: cat /proc/sys/kernel/tainted
     output_file: cat_proc_sys_kernel_tainted.txt
+  -
+    description: Display dmesg messages related to loaded modules tainting the kernel.
+    supported_os: [linux]
+    collector: command
+    command: dmesg | grep -i taint
+    output_file: modules_tainting_the_kernel_dmesg.txt
   -
     description: Display what modules are marked at tainting the kernel.
     supported_os: [linux]


### PR DESCRIPTION
Add new artifact to collect dmesg messages showing modules tainting the kernel.