### PR TITLE
artif: collect /proc/*/stat

### DIFF
--- a/artifacts/live_response/process/procfs_information.yaml
+++ b/artifacts/live_response/process/procfs_information.yaml
@@ -203,6 +203,14 @@ artifacts:
     output_directory: /live_response/process/proc/%line%
     output_file: status.txt
   -
+    description: Collect stat of each process.
+    supported_os: [linux]
+    collector: command
+    foreach: for pid in /proc/[0-9]*; do echo ${pid} | sed -e 's:/proc/::'; done
+    command: cat /proc/%line%/stat
+    output_directory: /live_response/process/proc/%line%
+    output_file: stat.txt
+  -
     description: Display the list of UNIX sockets.
     supported_os: [linux]
     collector: command
@@ -230,7 +238,7 @@ artifacts:
     command: astrings /proc/%line%/environ
     output_directory: /live_response/process/proc/%line%
     output_file: environ.txt
-  
+
   # macos
   -
     description: Collect running processes executable path.


### PR DESCRIPTION
Added an artifact to collect /proc/*/stat.
Its 9th field is the task flags. So, it can help to identify if a process is kernel thread or not.

(The value of 9th field) & PF_KTHREAD (0x00200000) != 0 : Kernel thread
(The value of 9th field) & PF_KTHREAD (0x00200000) == 0 : Not kernel thread

Incidentally, newer Linux kernel provides Kthread field in /proc/*/status.
https://lore.kernel.org/lkml/0589177d-c1f9-7320-b668-c103e34e8800@infradead.org/T/
https://x.com/CraigHRowland/status/1818770196792066123
