### PR TITLE
Collection of FreeBSD installed packages database

### DIFF
--- a/artifacts/files/packages/pkg_contents.yaml
+++ b/artifacts/files/packages/pkg_contents.yaml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 2.1
 artifacts:
   -
     description: Collect package table of contents files.
@@ -17,3 +17,8 @@ artifacts:
     supported_os: [solaris]
     collector: file
     path: /var/pkg/publisher/*/pkg
+  -
+    description: Collect installed packages database.
+    supported_os: [freebsd]
+    collector: file
+    path: /var/db/pkg/local.sqlite


### PR DESCRIPTION
Hi,

while checking some stuff around installed packages on FreeBSD, I noticed that UAC does not yet cover the database file giving info about installed packages.
Interesting information in the database includes: 
+ user accounts added by packages
+ SHA256 hashes for files added by packages

tested on FreeBSD 14.0-RELEASE

Kind Regards