### PR TITLE
artif: collect persistence via package managers

### DIFF
--- a/artifacts/files/packages/apt.yaml
+++ b/artifacts/files/packages/apt.yaml
@@ -3,7 +3,7 @@ version: 1.0
 # ref: https://www.elastic.co/security-labs/sequel-on-persistence-mechanisms
 artifacts:
   -
-    description: Collect script files under /etc/apt/apt.conf.d/ .
+    description: Collect script files under /etc/apt/apt.conf.d/ directory.
     supported_os: [linux]
     collector: file
     path: /etc/apt/apt.conf.d

--- a/artifacts/files/packages/apt.yaml
+++ b/artifacts/files/packages/apt.yaml
@@ -1,0 +1,9 @@
+version: 1.0
+# APT can be used to run persistence.
+# ref: https://www.elastic.co/security-labs/sequel-on-persistence-mechanisms
+artifacts:
+  -
+    description: Collect script files under /etc/apt/apt.conf.d/ .
+    supported_os: [linux]
+    collector: file
+    path: /etc/apt/apt.conf.d

--- a/artifacts/files/packages/dnf.yaml
+++ b/artifacts/files/packages/dnf.yaml
@@ -1,0 +1,16 @@
+version: 1.0
+# DNF can be used to run persistence.
+# ref: https://www.elastic.co/security-labs/sequel-on-persistence-mechanisms
+artifacts:
+  -
+    description: Collect configuration files under /etc/dnf/pluginconf.d/ .
+    supported_os: [linux]
+    collector: file
+    path: /etc/dnf/pluginconf.d
+  -
+    description: Collect script files under dnf-plugins directories .
+    supported_os: [linux]
+    collector: file
+    path: /
+    name_pattern: ["dnf-plugins"]
+    file_type: [d]

--- a/artifacts/files/packages/dnf.yaml
+++ b/artifacts/files/packages/dnf.yaml
@@ -3,12 +3,12 @@ version: 1.0
 # ref: https://www.elastic.co/security-labs/sequel-on-persistence-mechanisms
 artifacts:
   -
-    description: Collect configuration files under /etc/dnf/pluginconf.d/ .
+    description: Collect configuration files under /etc/dnf/pluginconf.d/ directory.
     supported_os: [linux]
     collector: file
     path: /etc/dnf/pluginconf.d
   -
-    description: Collect script files under dnf-plugins directories .
+    description: Collect script files under dnf-plugins directories.
     supported_os: [linux]
     collector: file
     path: /

--- a/artifacts/files/packages/yum.yaml
+++ b/artifacts/files/packages/yum.yaml
@@ -1,0 +1,14 @@
+version: 1.0
+# YUM can be used to run persistence.
+# ref: https://www.elastic.co/security-labs/sequel-on-persistence-mechanisms
+artifacts:
+  -
+    description: Collect configuration files under /etc/yum/pluginconf.d/ .
+    supported_os: [linux]
+    collector: file
+    path: /etc/yum/pluginconf.d
+  -
+    description: Collect script files under /usr/lib/yum-plugins/ .
+    supported_os: [linux]
+    collector: file
+    path: /usr/lib/yum-plugins

--- a/artifacts/files/packages/yum.yaml
+++ b/artifacts/files/packages/yum.yaml
@@ -3,12 +3,12 @@ version: 1.0
 # ref: https://www.elastic.co/security-labs/sequel-on-persistence-mechanisms
 artifacts:
   -
-    description: Collect configuration files under /etc/yum/pluginconf.d/ .
+    description: Collect configuration files under /etc/yum/pluginconf.d/ directory.
     supported_os: [linux]
     collector: file
     path: /etc/yum/pluginconf.d
   -
-    description: Collect script files under /usr/lib/yum-plugins/ .
+    description: Collect script files under /usr/lib/yum-plugins/ directory.
     supported_os: [linux]
     collector: file
     path: /usr/lib/yum-plugins


### PR DESCRIPTION
Add artifacts to collect package manager plugins/scripts. They can be used as persistence.