### PR TITLE
artif: collect Git persistence

### DIFF
--- a/artifacts/files/applications/git.yaml
+++ b/artifacts/files/applications/git.yaml
@@ -1,0 +1,28 @@
+version: 1.0
+artifacts:
+# Git hooks/Git pager can be used to run persistence.
+# ref: https://www.elastic.co/security-labs/sequel-on-persistence-mechanisms
+  -
+    description: Collect Git hooks under .git/hooks .
+    supported_os: [linux]
+    collector: file
+    path: /
+    path_pattern: ["*/.git/hooks/*"]
+    file_type: [f]
+  -
+    description: Collect /etc/gitconfig .
+    supported_os: [linux]
+    collector: file
+    path: /etc/gitconfig
+  -
+    description: Collect ~/.gitconfig .
+    supported_os: [linux]
+    collector: file
+    path: /%user_home%/.gitconfig
+    exclude_nologin_users: true
+  -
+    description: Collect ~/.config/git/gitconfig .
+    supported_os: [linux]
+    collector: file
+    path: /%user_home%/.config/git/config
+    exclude_nologin_users: true

--- a/artifacts/files/applications/git.yaml
+++ b/artifacts/files/applications/git.yaml
@@ -3,25 +3,25 @@ artifacts:
 # Git hooks/Git pager can be used to run persistence.
 # ref: https://www.elastic.co/security-labs/sequel-on-persistence-mechanisms
   -
-    description: Collect Git hooks under .git/hooks .
+    description: Collect Git hooks under .git/hooks directory.
     supported_os: [linux]
     collector: file
     path: /
     path_pattern: ["*/.git/hooks/*"]
     file_type: [f]
   -
-    description: Collect /etc/gitconfig .
+    description: Collect /etc/gitconfig file.
     supported_os: [linux]
     collector: file
     path: /etc/gitconfig
   -
-    description: Collect ~/.gitconfig .
+    description: Collect ~/.gitconfig file.
     supported_os: [linux]
     collector: file
     path: /%user_home%/.gitconfig
     exclude_nologin_users: true
   -
-    description: Collect ~/.config/git/gitconfig .
+    description: Collect ~/.config/git/gitconfig file.
     supported_os: [linux]
     collector: file
     path: /%user_home%/.config/git/config

--- a/profiles/ir_triage.yaml
+++ b/profiles/ir_triage.yaml
@@ -28,9 +28,9 @@ artifacts:
   - files/applications/lesshst.yaml
   - files/applications/viminfo.yaml
   - files/applications/wget.yaml
+  - files/applications/git.yaml
   - files/logs/*
   - files/packages/*
   - files/shell/*
   - files/ssh/*
   - files/system/*
-  

--- a/profiles/ir_triage.yaml
+++ b/profiles/ir_triage.yaml
@@ -25,10 +25,10 @@ artifacts:
   - live_response/vms/*
   - chkrootkit/chkrootkit.yaml
   - hash_executables/hash_executables.yaml
+  - files/applications/git.yaml
   - files/applications/lesshst.yaml
   - files/applications/viminfo.yaml
   - files/applications/wget.yaml
-  - files/applications/git.yaml
   - files/logs/*
   - files/packages/*
   - files/shell/*


### PR DESCRIPTION
Add new artifacts to collect Git persistence.
Git hooks and Git pager can be used as persistence.