### PR TITLE
add artifacts around Solaris system accounting

### DIFF
--- a/artifacts/files/system/acct.yaml
+++ b/artifacts/files/system/acct.yaml
@@ -1,7 +1,7 @@
 version: 1.0
 artifacts:
   # system accounting files, covering processes that terminated on the system, allowing one to see past program executions
-  # this is deactivated by default, but quite usefull when active
+  # this is deactivated by default, but quite useful when active
   -
     description: Collect system accounting files.
     supported_os: [freebsd, netbsd, openbsd]
@@ -19,4 +19,24 @@ artifacts:
     supported_os: [freebsd, netbsd, openbsd]
     collector: file
     path: /var/account/savacct
+    ignore_date_range: true
+  -
+    description: Collect system accounting files.
+    supported_os: [solaris]
+    collector: file
+    path: /var/adm/pacct*
+    ignore_date_range: true
+  -
+    description: Collect system accounting summary files.
+    supported_os: [solaris]
+    collector: file
+    path: /var/adm/acct
+    max_file_size: 1073741824 # 1GB
+    ignore_date_range: true
+  -
+    description: Collect extended system accounting files from default location.
+    supported_os: [solaris]
+    collector: file
+    path: /var/adm/exacct
+    max_file_size: 1073741824 # 1GB
     ignore_date_range: true

--- a/artifacts/files/system/acct.yaml
+++ b/artifacts/files/system/acct.yaml
@@ -1,4 +1,4 @@
-version: 1.0
+version: 2.0
 artifacts:
   # system accounting files, covering processes that terminated on the system, allowing one to see past program executions
   # this is deactivated by default, but quite useful when active

--- a/artifacts/live_response/system/acctadm.yaml
+++ b/artifacts/live_response/system/acctadm.yaml
@@ -1,0 +1,10 @@
+version: 1.0
+condition: command_exists "acctadm"
+output_directory: /live_response/system
+artifacts:
+  -
+    description: Shows the configuration for extended accounting.
+    supported_os: [solaris]
+    collector: command
+    command: acctadm
+    output_file: acctadm.txt

--- a/artifacts/live_response/system/acctcom.yaml
+++ b/artifacts/live_response/system/acctcom.yaml
@@ -6,7 +6,7 @@ artifacts:
     description: Shows the last commands executed in a reverse order based on the default accounting file.
     supported_os: [solaris]
     collector: command
-    command: acctcom -f -i -t
+    command: acctcom -f -i -t /var/adm/pacct
     output_file: acctcom_-f_-i_-t.txt
   -
     description: Shows the last commands executed in a reverse order from the historic accounting files.

--- a/artifacts/live_response/system/acctcom.yaml
+++ b/artifacts/live_response/system/acctcom.yaml
@@ -1,0 +1,17 @@
+version: 1.0
+condition: command_exists "acctcom"
+output_directory: /live_response/system
+artifacts:
+  -
+    description: Shows the last commands executed in a reverse order based on the default accounting file.
+    supported_os: [solaris]
+    collector: command
+    command: acctcom -f -i -t
+    output_file: acctcom_-f_-i_-t.txt
+  -
+    description: Shows the last commands executed in a reverse order from the historic accounting files.
+    supported_os: [solaris]
+    collector: command
+    foreach: ls /var/adm/pacct*
+    command: acctcom -f -i -t %line%
+    output_file: acctcom_-f_-i_-t_%line%.txt

--- a/artifacts/live_response/system/lastcomm.yaml
+++ b/artifacts/live_response/system/lastcomm.yaml
@@ -4,7 +4,7 @@ output_directory: /live_response/system
 artifacts:
   -
     description: Shows the last commands executed in a reverse order based on the default accounting file.
-    supported_os: [freebsd, netbsd, openbsd]
+    supported_os: [freebsd, netbsd, openbsd, solaris]
     collector: command
     command: lastcomm
     output_file: lastcomm.txt
@@ -15,3 +15,9 @@ artifacts:
     foreach: ls /var/account/acct*
     command: lastcomm -f %line%
     output_file: lastcomm_%line%.txt
+  -
+    description: Shows the last commands executed in a reverse order based on the extended accounting file.
+    supported_os: [solaris]
+    collector: command
+    command: lastcomm -x
+    output_file: lastcomm_-x.txt

--- a/artifacts/live_response/system/lastcomm.yaml
+++ b/artifacts/live_response/system/lastcomm.yaml
@@ -1,4 +1,4 @@
-version: 1.0
+version: 2.0
 condition: command_exists "lastcomm"
 output_directory: /live_response/system
 artifacts:


### PR DESCRIPTION
Hi,

I've added some artifacts around system accounting on Solaris. All the referenced data is deactivated by default. But if available, it seems useful to investigate activity on the system.

The additions cover following points
+ default file location for the "normal" system accounting files (covers processes)
+ default file location for the "extended" system accounting files (covers processes, tasks, data link usage and IPQoS info, each in separate files and with separate settings)
+ live response to get the configuration of extended system accounting (both where the files are stored and what data is tracked)
+ live response to parse data from the normal system accounting files and the extended system accounting files using builtin tools

If you want an example collection with the data, I would be happy to share one. :)

Kind Regards