### PR TITLE
artif: get findmnt and lsblk results in JSON format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 - live_response/packages/conary.yaml: Added collection of the list of installed packages managed by the Conary package manager [linux] (by [Pierre-Gronau-ndaal](https://github.com/Pierre-Gronau-ndaal)).
 - live_response/packages/dpkg.yaml: Updated to verify all packages to compare information about the installed files in the package with information about the files taken from the package metadata stored in the dpkg database [linux] ([mnrkbys](https://github.com/mnrkbys)).
 - live_response/packages/package_owns_file.yaml: Added collection of which installed package owns a specific file or command. Note that this artifact is resource-intensive and time-consuming to execute, so it is disabled by default in all profiles [linux] ([mnrkbys](https://github.com/mnrkbys)).
+- live_response/storage/findmnt.yaml: Added JSON output format for listing all mounted file systems [linux] ([mnrkbys](https://github.com/mnrkbys)).
+- live_response/storage/lsblk.yaml: Added JSON output format for listing block devices [linux] ([mnrkbys](https://github.com/mnrkbys)).
 - live_response/system/coredump.yaml: Added collection of core dump files information [linux] ([mnrkbys](https://github.com/mnrkbys)).
 - live_response/system/getcap.yaml: Added functionality to collect the list of files with associated process capabilities [linux] ([mnrkbys](https://github.com/mnrkbys)).
 - live_response/system/ulimit.yaml: Added collection of all resource limits information [all] ([mnrkbys](https://github.com/mnrkbys)).

--- a/artifacts/live_response/storage/findmnt.yaml
+++ b/artifacts/live_response/storage/findmnt.yaml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 2.1
 condition: command_exists "findmnt"
 output_directory: /live_response/storage
 artifacts:
@@ -8,4 +8,9 @@ artifacts:
     collector: command
     command: findmnt --ascii
     output_file: findmnt.txt
-    
+  -
+    description: Displays all mounted file systems in the tree-like format as JSON.
+    supported_os: [linux]
+    collector: command
+    command: findmnt -J
+    output_file: findmnt_-J.txt

--- a/artifacts/live_response/storage/lsblk.yaml
+++ b/artifacts/live_response/storage/lsblk.yaml
@@ -1,4 +1,4 @@
-version: 3.0
+version: 3.1
 condition: command_exists "lsblk"
 output_directory: /live_response/storage
 artifacts:
@@ -9,15 +9,32 @@ artifacts:
     command: lsblk
     output_file: lsblk.txt
   -
+    description: List block devices as JSON.
+    supported_os: [linux]
+    collector: command
+    command: lsblk -J
+    output_file: lsblk_-J.txt
+  -
     description: List block devices.
     supported_os: [linux]
     collector: command
     command: lsblk -l
     output_file: lsblk_-l.txt
   -
+    description: List block devices as JSON.
+    supported_os: [linux]
+    collector: command
+    command: lsblk -l -J
+    output_file: lsblk_-l_-J.txt
+  -
     description: List block devices including information about filesystems.
     supported_os: [linux]
     collector: command
     command: lsblk -f
     output_file: lsblk_-f.txt
-    
+  -
+    description: List block devices including information about filesystems as JSON.
+    supported_os: [linux]
+    collector: command
+    command: lsblk -f -J
+    output_file: lsblk_-f_-J.txt


### PR DESCRIPTION
JSON format is easier to parse in scripts than plain text output.