### PR TITLE
Update snap.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - live_response/packages/package_owns_file.yaml: Added collection of which installed package owns a specific file or command. Note that this artifact is resource-intensive and time-consuming to execute, so it is disabled by default in all profiles [linux] ([mnrkbys](https://github.com/mnrkbys)).
 - live_response/packages/paludis.yaml: Added collection of the list of installed packages managed by the Paludis package manager [linux] (by [Pierre-Gronau-ndaal](https://github.com/Pierre-Gronau-ndaal)).
 - live_response/packages/portage.yaml: Added the collection of installed package lists using the Portage package management system [linux] (by [Pierre-Gronau-ndaal](https://github.com/Pierre-Gronau-ndaal)).
+- live_response/packages/snap.yaml: Updated collection to display installed packages including all revisions [linux] (by [Pierre-Gronau-ndaal](https://github.com/Pierre-Gronau-ndaal)).
 - live_response/storage/findmnt.yaml: Added JSON output format for listing all mounted file systems [linux] ([mnrkbys](https://github.com/mnrkbys)).
 - live_response/storage/lsblk.yaml: Added JSON output format for listing block devices [linux] ([mnrkbys](https://github.com/mnrkbys)).
 - live_response/system/coredump.yaml: Added collection of core dump files information [linux] ([mnrkbys](https://github.com/mnrkbys)).

--- a/artifacts/live_response/packages/snap.yaml
+++ b/artifacts/live_response/packages/snap.yaml
@@ -13,5 +13,5 @@ artifacts:
     supported_os: [linux]
     collector: command
     command: snap list --all
-    output_file: snap_list_all.txt
+    output_file: snap_list_--all.txt
     

--- a/artifacts/live_response/packages/snap.yaml
+++ b/artifacts/live_response/packages/snap.yaml
@@ -9,9 +9,8 @@ artifacts:
     command: snap list
     output_file: snap_list.txt
   -
-    description: Display installed Snap packages.
+    description: Display installed Snap packages including all revisions.
     supported_os: [linux]
     collector: command
     command: snap list --all
     output_file: snap_list_--all.txt
-    

--- a/artifacts/live_response/packages/snap.yaml
+++ b/artifacts/live_response/packages/snap.yaml
@@ -8,4 +8,10 @@ artifacts:
     collector: command
     command: snap list
     output_file: snap_list.txt
-  
+  -
+    description: Display installed Snap packages.
+    supported_os: [linux]
+    collector: command
+    command: snap list --all
+    output_file: snap_list_all.txt
+    


### PR DESCRIPTION
The --all option is particularly useful when you want to: View the history of snap updates on your system
Identify older versions of snaps that can be removed to free up disk space Troubleshoot issues related to specific snap revisions For example, if you're experiencing problems with a recently updated snap, using snap list --all can help you identify the previous working version, which you might want to revert to using the snap revert command1. In summary, while snap list gives you a quick overview of your current snap environment, snap list --all provides a more detailed history and status of all snap packages and their revisions on your system.