### PR TITLE
artif: add date before ps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable changes to this project will be documented in this file.
 - `files/system/job_scheduler.yaml`: Updated to include anacron job scheduler [aix, esxi, freebsd, linux, netbsd, netscaler, openbsd, solaris]. (by [0xThiebaut](https://github.com/0xThiebaut))
 - `live_response/packages/dpkg.yaml`: Updated to validate all installed packages by comparing the installed files against the package metadata stored in the dpkg database [linux]. (by [Pierre-Gronau-ndaal](https://github.com/Pierre-Gronau-ndaal))
 - `live_response/packages/snap.yaml`: Updated collection to display installed packages including all revisions [linux]. (by [Pierre-Gronau-ndaal](https://github.com/Pierre-Gronau-ndaal))
+- `live_response/process/ps.yaml`: Updated to collect the system date before reporting a snapshot of the current processes including elapsed time since the process was started [all].
 
 ### Fixed
 

--- a/artifacts/live_response/process/ps.yaml
+++ b/artifacts/live_response/process/ps.yaml
@@ -1,4 +1,4 @@
-version: 3.0
+version: 4.0
 output_directory: /live_response/process
 artifacts:
   -
@@ -38,17 +38,38 @@ artifacts:
     command: ps -efl
     output_file: ps_-efl.txt
   -
+    description: Collect system date before reporting a snapshot of the current processes including elapsed time since the process was started.
+    supported_os: [aix, solaris]
+    collector: command
+    condition: ps -eo pid,user,etime,args
+    command: date
+    output_file: date_before_ps_-eo_pid_user_etime_args.txt
+  -
     description: Report a snapshot of the current processes including elapsed time since the process was started.
     supported_os: [aix, solaris]
     collector: command
     command: ps -eo pid,user,etime,args
     output_file: ps_-eo_pid_user_etime_args.txt
   -
+    description: Collect system date before reporting a snapshot of the current processes including elapsed time since the process was started.
+    supported_os: [freebsd, linux, macos, netbsd, netscaler, openbsd]
+    collector: command
+    condition: ps -axo pid,user,etime,args
+    command: date
+    output_file: date_before_ps_-axo_pid_user_etime_args.txt
+  -
     description: Report a snapshot of the current processes including elapsed time since the process was started.
     supported_os: [freebsd, linux, macos, netbsd, netscaler, openbsd]
     collector: command
     command: ps -axo pid,user,etime,args
     output_file: ps_-axo_pid_user_etime_args.txt
+  -
+    description: Collet system date before reporting a snapshot of the current processes including time the command started.
+    supported_os: [freebsd, linux, macos, netbsd, netscaler, openbsd]
+    collector: command
+    condition: ps -axo pid,user,lstart,args
+    command: date
+    output_file: date_before_ps_-axo_pid_user_lstart_args.txt
   -
     description: Report a snapshot of the current processes including time the command started.
     supported_os: [freebsd, linux, macos, netbsd, netscaler, openbsd]
@@ -61,6 +82,13 @@ artifacts:
     collector: command
     command: ps -axo pid,user,cgroup
     output_file: ps_-axo_pid_user_cgroup.txt
+  -
+    description: Collect system date before reporting a snapshot of the current processes including used time, verbose, session ID and process group, state and type.
+    supported_os: [esxi]
+    collector: command
+    condition: ps -P -T -c -g -s -t -J
+    command: date
+    output_file: date_before_ps_-P_-T_-c_-g_-s_-t_-J.txt
   -
     description: Report a snapshot of the current processes including used time, verbose, session ID and process group, state and type.
     supported_os: [esxi]


### PR DESCRIPTION
Updated to collect the system date before reporting a snapshot of the current processes including elapsed time since the process was started.