### PR TITLE
fix: add file_type validation when max or min file size is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Resolved an issue where the `hash` and `stat` collectors failed to function correctly when the `%user_home%` variable was included in the path property. ([#289](https://github.com/tclahr/uac/issues/289))
+- Resolved an issue where directories were also being collected when `max_file_size` or `min_file_size` was set. ([#338](https://github.com/tclahr/uac/issues/338))
 
 ### Profiles
 

--- a/artifacts/files/logs/advanced_log_search.yaml
+++ b/artifacts/files/logs/advanced_log_search.yaml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 2.1
 artifacts:
   -
     description: Collect all log files and directories.
@@ -6,5 +6,6 @@ artifacts:
     collector: file
     path: /
     name_pattern: ["*.[Ll][Oo][Gg]", "*.[Ll][Oo][Gg].*", "[Ll][Oo][Gg]", "[Ll][Oo][Gg][Ss]"]
+    file_type: [f]
     max_file_size: 1073741824 # 1GB
   

--- a/artifacts/files/logs/apache.yaml
+++ b/artifacts/files/logs/apache.yaml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 2.1
 artifacts:
   -
     description: Collect Apache logs.
@@ -6,22 +6,26 @@ artifacts:
     collector: file
     path: /var/log
     name_pattern: ["access_log*", "access.log*", "error_log*", "error.log*"]
+    file_type: [f]
     max_file_size: 1073741824 # 1GB
   -
     description: Collect Apache logs.
     supported_os: [all]
     collector: file
     path: /var/log/apache
+    file_type: [f]
     max_file_size: 1073741824 # 1GB
   -
     description: Collect Apache logs.
     supported_os: [all]
     collector: file
     path: /var/log/apache2
+    file_type: [f]
     max_file_size: 1073741824 # 1GB
   -
     description: Collect Apache logs.
     supported_os: [all]
     collector: file
     path: /var/log/httpd
+    file_type: [f]
     max_file_size: 1073741824 # 1GB

--- a/artifacts/files/logs/macos.yaml
+++ b/artifacts/files/logs/macos.yaml
@@ -1,28 +1,32 @@
-version: 2.0
+version: 2.1
 artifacts:
   -
     description: Collect fseventsd system logs.
     supported_os: [macos]
     collector: file
     path: /.fseventsd
+    file_type: [f]
     max_file_size: 1073741824 # 1GB
   -
     description: Collect fseventsd system logs.
     supported_os: [macos]
     collector: file
     path: /System/Volumes/*/.fseventsd
+    file_type: [f]
     max_file_size: 1073741824 # 1GB
   -
     description: Collect system logs.
     supported_os: [macos]
     collector: file
     path: /Library/Logs
+    file_type: [f]
     max_file_size: 1073741824 # 1GB
   -
     description: Collect user applications logs.
     supported_os: [macos]
     collector: file
     path: /%user_home%/Library/Logs
+    file_type: [f]
     max_file_size: 1073741824 # 1GB
   -
     description: Collect auditd logs.
@@ -30,5 +34,6 @@ artifacts:
     supported_os: [macos]
     collector: file
     path: /var/audit
+    file_type: [f]
     max_file_size: 1073741824 # 1GB
   

--- a/artifacts/files/logs/macos_unified_logs.yaml
+++ b/artifacts/files/logs/macos_unified_logs.yaml
@@ -1,4 +1,4 @@
-version: 4.1
+version: 4.2
 artifacts:
   -
     description: Collect macOS Unified Logs tracev3 files.
@@ -21,18 +21,21 @@ artifacts:
     supported_os: [macos]
     collector: file
     path: /private/var/log/asl.db
+    file_type: [f]
     max_file_size: 1073741824 # 1GB
   -
     description: Collect macOS Apple System Logs (ASL) files.
     supported_os: [macos]
     collector: file
     path: /private/var/log/asl.log
+    file_type: [f]
     max_file_size: 1073741824 # 1GB
   -
     description: Collect macOS Apple System Logs (ASL) files.
     supported_os: [macos]
     collector: file
     path: /private/var/log/asl/*
+    file_type: [f]
     max_file_size: 1073741824 # 1GB
     
 # References:

--- a/artifacts/files/logs/netscaler.yaml
+++ b/artifacts/files/logs/netscaler.yaml
@@ -1,20 +1,23 @@
-version: 1.0
+version: 1.1
 artifacts:
   -
     description: Collect nslog logs.
     supported_os: [netscaler]
     collector: file
     path: /var/nslog
+    file_type: [f]
     max_file_size: 1073741824 # 1GB
   -
     description: Collect nsproflog logs.
     supported_os: [netscaler]
     collector: file
     path: /var/nsproflog
+    file_type: [f]
     max_file_size: 1073741824 # 1GB
   -
     description: Collect nssynclog logs.
     supported_os: [netscaler]
     collector: file
     path: /var/nssynclog
+    file_type: [f]
     max_file_size: 1073741824 # 1GB

--- a/artifacts/files/logs/nginx.yaml
+++ b/artifacts/files/logs/nginx.yaml
@@ -1,4 +1,4 @@
-version: 1.0
+version: 1.1
 artifacts:
   -
     description: Collect nginx logs.
@@ -6,11 +6,13 @@ artifacts:
     collector: file
     path: /var/log
     name_pattern: ["*access_log*", "*access.log*", "*error_log*", "*error.log*"]
+    file_type: [f]
     max_file_size: 1073741824 # 1GB
   -
     description: Collect nginx logs.
     supported_os: [all]
     collector: file
     path: /var/log/nginx
+    file_type: [f]
     max_file_size: 1073741824 # 1GB
 

--- a/artifacts/files/logs/run_log.yaml
+++ b/artifacts/files/logs/run_log.yaml
@@ -1,9 +1,10 @@
-version: 1.0
+version: 1.1
 artifacts:
   -
     description: Collect /run/log files.
     supported_os: [linux]
     collector: file
     path: /run/log
+    file_type: [f]
     max_file_size: 1073741824 # 1GB
   

--- a/artifacts/files/logs/solaris.yaml
+++ b/artifacts/files/logs/solaris.yaml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 2.1
 artifacts:
   -
     description: Collect lastlog log file.
@@ -20,10 +20,12 @@ artifacts:
     supported_os: [solaris]
     collector: file
     path: /var/svc/log
+    file_type: [f]
     max_file_size: 1073741824 # 1GB
   -
     description: Collect webui log files.
     supported_os: [solaris]
     collector: file
     path: /var/webui/logs
+    file_type: [f]
     max_file_size: 1073741824 # 1GB

--- a/artifacts/files/logs/tomcat.yaml
+++ b/artifacts/files/logs/tomcat.yaml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 2.1
 artifacts:
   -
     description: Collect Apache Tomcat logs.
@@ -6,4 +6,5 @@ artifacts:
     collector: file
     path: /
     name_pattern: ["access_log*", "error_log*", "httpd-access.log*", "httpd-error.log*", "catalina.out"]
+    file_type: [f]
     max_file_size: 1073741824 # 1GB

--- a/artifacts/files/logs/var_adm.yaml
+++ b/artifacts/files/logs/var_adm.yaml
@@ -1,8 +1,9 @@
-version: 2.0
+version: 2.1
 artifacts:
   -
     description: Collect /var/adm logs.
     supported_os: [aix, freebsd, linux, netbsd, netscaler, openbsd, solaris]
     collector: file
     path: /var/adm
+    file_type: [f]
     max_file_size: 1073741824 # 1GB

--- a/artifacts/files/logs/var_log.yaml
+++ b/artifacts/files/logs/var_log.yaml
@@ -1,14 +1,16 @@
-version: 3.0
+version: 3.1
 artifacts:
   -
     description: Collect /var/log logs.
     supported_os: [aix, esxi, freebsd, linux, netbsd, netscaler, openbsd, solaris]
     collector: file
     path: /var/log
+    file_type: [f]
     max_file_size: 1073741824 # 1GB
   -
     description: Collect /private/var/log logs.
     supported_os: [macos]
     collector: file
     path: /private/var/log
+    file_type: [f]
     max_file_size: 1073741824 # 1GB

--- a/artifacts/files/logs/var_run_log.yaml
+++ b/artifacts/files/logs/var_run_log.yaml
@@ -1,9 +1,10 @@
-version: 1.0
+version: 1.1
 artifacts:
   -
     description: Collect /var/run/log logs.
     supported_os: [esxi]
     collector: file
     path: /var/run/log
+    file_type: [f]
     max_file_size: 1073741824 # 1GB
   

--- a/artifacts/files/system/acct.yaml
+++ b/artifacts/files/system/acct.yaml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 2.1
 artifacts:
   # system accounting files, covering processes that terminated on the system, allowing one to see past program executions
   # this is deactivated by default, but quite useful when active
@@ -31,6 +31,7 @@ artifacts:
     supported_os: [solaris]
     collector: file
     path: /var/adm/acct
+    file_type: [f]
     max_file_size: 1073741824 # 1GB
     ignore_date_range: true
   -
@@ -38,5 +39,6 @@ artifacts:
     supported_os: [solaris]
     collector: file
     path: /var/adm/exacct
+    file_type: [f]
     max_file_size: 1073741824 # 1GB
     ignore_date_range: true

--- a/artifacts/files/system/netscaler.yaml
+++ b/artifacts/files/system/netscaler.yaml
@@ -1,4 +1,4 @@
-version: 3.0
+version: 3.1
 artifacts:
   -
     description: Collect system configuration files.
@@ -11,18 +11,21 @@ artifacts:
     supported_os: [netscaler]
     collector: file
     path: /var/vpn
+    file_type: [f]
     max_file_size: 10485760 # 10MB
   -
     description: Collect files from /var/netscaler/logon.
     supported_os: [netscaler]
     collector: file
     path: /var/netscaler/logon
+    file_type: [f]
     max_file_size: 10485760 # 10MB
   -
     description: Collect files from /netscaler/ns_gui.
     supported_os: [netscaler]
     collector: file
     path: /netscaler/ns_gui
+    file_type: [f]
     max_file_size: 10485760 # 10MB
 
 # References:

--- a/lib/validate_artifact.sh
+++ b/lib/validate_artifact.sh
@@ -471,6 +471,12 @@ _validate_artifact()
                 _error_msg "artifact: missing 'path' property."
                 return 1
               fi
+              if [ -n "${__va_max_file_size}" ] || [ -n "${__va_min_file_size}" ]; then
+                if [ "${__va_file_type}" != "f" ]; then
+                  _error_msg "artifact: 'file_type' must be of type 'f' when using 'max_file_size' or 'min_file_size'."
+                  return 1
+                fi
+              fi
               if [ -n "${__va_command}" ]; then
                 _error_msg "artifact: invalid 'command' property for '${__va_collector}' collector."
                 return 1


### PR DESCRIPTION
Add validation to check if `file_type` was set to `f` when `max_file_size` or `min_file_size` is set. 
All artifacts that have max_file_size or min_file_size were also updated.

This fixes issue #338

**Before** the fix:

```yaml
version: 2.0
artifacts:
  -
    description: Collect all log files and directories.
    supported_os: [all]
    collector: file
    path: /
    name_pattern: ["*.[Ll][Oo][Gg]", "*.[Ll][Oo][Gg].*", "[Ll][Oo][Gg]", "[Ll][Oo][Gg][Ss]"]
    max_file_size: 1073741824 # 1GB
```

```shell
$ ./uac --validate-artifact ./artifacts/files/logs/advanced_log_search.yaml 
Validating artifact ./artifacts/files/logs/advanced_log_search.yaml
uac: artifact: 'file_type' must be of type 'f' when using 'max_file_size' or 'min_file_size'.
```

**After** the fix:

```yaml
version: 2.1
artifacts:
  -
    description: Collect all log files and directories.
    supported_os: [all]
    collector: file
    path: /
    name_pattern: ["*.[Ll][Oo][Gg]", "*.[Ll][Oo][Gg].*", "[Ll][Oo][Gg]", "[Ll][Oo][Gg][Ss]"]
    file_type: [f]
    max_file_size: 1073741824 # 1GB
```

```shell
$ ./uac --validate-artifact ./artifacts/files/logs/advanced_log_search.yaml
Validating artifact ./artifacts/files/logs/advanced_log_search.yaml
uac: artifact successfully validated.
```
