### PR TITLE
add artifact to search for files with unknown group and user ID names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,10 +48,12 @@ All notable changes to this project will be documented in this file.
 - `live_response/storage/lsblk.yaml`: Added JSON output support for listing block devices [linux]. (by [mnrkbys](https://github.com/mnrkbys))
 - `live_response/system/coredump.yaml`: Added collection of information about core dump files [linux]. (by [mnrkbys](https://github.com/mnrkbys))
 - `live_response/system/getcap.yaml`: Added functionality to collect a list of files with associated process capabilities [linux]. (by [mnrkbys](https://github.com/mnrkbys))
+- `live_response/system/group_name_unknown_files.yaml`: List files with an unknown group ID name [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris].
 - `live_response/system/immutable_files.yaml`: Added functionality to list immutable files on the system [linux].
 - `live_response/system/journalctl.yaml`: Added collection of boot time period listings using `journalctl` [linux]. (by [mnrkbys](https://github.com/mnrkbys))
 - `live_response/system/sudo_lectured.yaml`: Added collection of the timestamps of users who saw the sudo lecture message [all]. (by [mnrkbys](https://github.com/mnrkbys))
 - `live_response/system/ulimit.yaml`: Added collection of all resource limits information [all]. (by [mnrkbys](https://github.com/mnrkbys))
+- `live_response/system/user_name_unknown_files.yaml`: List files with an unknown user ID name [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris].
 - `memory_dump/coredump.yaml`: Added collection of core dump, ABRT, Apport, and kdump files [esxi, linux, netbsd]. (by [mnrkbys](https://github.com/mnrkbys))
 - `osquery/osquery.yaml`: Added collection of multiple artifacts using OSQuery tool. Please note that the `osqueryi` binary is not included in the UAC package and must be manually placed in the `bin` directory [linux]. (by [SolitudePy](https://github.com/SolitudePy))
 
@@ -75,6 +77,6 @@ All notable changes to this project will be documented in this file.
 
 ### New Artifact Properties
 
-- Introduced `redirect_stderr_to_stdout`: When enabled, this property redirects error messages (stderr) to standard output (stdout). Useful for debugging and ensuring complete logs.
 - Introduced `no_group`: Use this option to search for files that have a group ID (GID) that no longer exists in the system.
 - Incroduced `no_user`: Use this option to search for files that have a user ID (UID) that no longer exists in the system.
+- Introduced `redirect_stderr_to_stdout`: When enabled, this property redirects error messages (stderr) to standard output (stdout). Useful for debugging and ensuring complete logs.

--- a/artifacts/live_response/system/group_name_unknown_files.yaml
+++ b/artifacts/live_response/system/group_name_unknown_files.yaml
@@ -1,0 +1,218 @@
+version: 1.0
+output_directory: /live_response/system
+artifacts:
+  -
+    description: List files under / directory (no recursion, top-level only) with an unknown group ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /
+    max_depth: 1
+    file_type: [f]
+    no_group: true
+    output_file: group_name_unknown_files.txt
+  -
+    description: List files under /bin directory with an unknown group ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /bin
+    file_type: [f]
+    no_group: true
+    output_file: group_name_unknown_files.txt
+  -
+    description: List files under /sbin directory with an unknown group ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /sbin
+    file_type: [f]
+    no_group: true
+    output_file: group_name_unknown_files.txt
+  -
+    description: List files under /usr/bin directory with an unknown group ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /usr/bin
+    file_type: [f]
+    no_group: true
+    output_file: group_name_unknown_files.txt
+  -
+    description: List files under /usr/sbin directory with an unknown group ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /usr/sbin
+    file_type: [f]
+    no_group: true
+    output_file: group_name_unknown_files.txt
+  -
+    description: List files under /usr/local/bin directory with an unknown group ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /usr/local/bin
+    file_type: [f]
+    no_group: true
+    output_file: group_name_unknown_files.txt
+  -
+    description: List files under /usr/local/sbin directory with an unknown group ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /usr/local/sbin
+    file_type: [f]
+    no_group: true
+    output_file: group_name_unknown_files.txt
+  -
+    description: List files under /dev directory with an unknown group ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /dev
+    file_type: [f]
+    no_group: true
+    output_file: group_name_unknown_files.txt
+  -
+    description: List files under /etc directory with an unknown group ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /etc
+    file_type: [f]
+    no_group: true
+    output_file: group_name_unknown_files.txt
+  -
+    description: List files under /home directory (no recursion, top-level only) with an unknown group ID name.
+    supported_os: [aix, freebsd, linux, netbsd, netscaler, openbsd]
+    collector: find
+    path: /home
+    max_depth: 1
+    file_type: [f]
+    no_group: true
+    output_file: group_name_unknown_files.txt
+  -
+    description: List files under /export/home directory (no recursion, top-level only) with an unknown group ID name.
+    supported_os: [solaris]
+    collector: find
+    path: /export/home
+    max_depth: 1
+    file_type: [f]
+    no_group: true
+    output_file: group_name_unknown_files.txt
+  -
+    description: List files under /Users directory (no recursion, top-level only) with an unknown group ID name.
+    supported_os: [macos]
+    collector: find
+    path: /Users
+    max_depth: 1
+    file_type: [f]
+    no_group: true
+    output_file: group_name_unknown_files.txt
+  -
+    description: List files under user home directories (no recursion, top-level only) with an unknown group ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /%user_home%
+    max_depth: 1
+    file_type: [f]
+    no_group: true
+    exclude_nologin_users: true
+    output_file: group_name_unknown_files.txt
+  -
+    description: List files under /lib directory with an unknown group ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /lib
+    file_type: [f]
+    no_group: true
+    output_file: group_name_unknown_files.txt
+  -
+    description: List files under /lib32 directory with an unknown group ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /lib32
+    file_type: [f]
+    no_group: true
+    output_file: group_name_unknown_files.txt
+  -
+    description: List files under /lib64 directory with an unknown group ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /lib64
+    file_type: [f]
+    no_group: true
+    output_file: group_name_unknown_files.txt
+  -
+    description: List files under /usr/lib directory with an unknown group ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /usr/lib
+    file_type: [f]
+    no_group: true
+    output_file: group_name_unknown_files.txt
+  -
+    description: List files under /usr/lib32 directory with an unknown group ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /usr/lib32
+    file_type: [f]
+    no_group: true
+    output_file: group_name_unknown_files.txt
+  -
+    description: List files under /usr/lib64 directory with an unknown group ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /usr/lib64
+    file_type: [f]
+    no_group: true
+    output_file: group_name_unknown_files.txt
+  -
+    description: List files under /var/lib directory with an unknown group ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /var/lib
+    file_type: [f]
+    no_group: true
+    output_file: group_name_unknown_files.txt
+  -
+    description: List files under /run directory with an unknown group ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /run
+    file_type: [f]
+    no_group: true
+    output_file: group_name_unknown_files.txt
+  -
+    description: List files under /var/run directory with an unknown group ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /var/run
+    file_type: [f]
+    no_group: true
+    output_file: group_name_unknown_files.txt
+  -
+    description: List files under /tmp directory with an unknown group ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /tmp
+    file_type: [f]
+    no_group: true
+    output_file: group_name_unknown_files.txt
+  -
+    description: List files under /var/tmp directory with an unknown group ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /var/tmp
+    file_type: [f]
+    no_group: true
+    output_file: group_name_unknown_files.txt
+  -
+    description: List files under /run/tmp directory with an unknown group ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /run/tmp
+    file_type: [f]
+    no_group: true
+    output_file: group_name_unknown_files.txt
+  -
+    description: List files under /usr/local directory with an unknown group ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /usr/local
+    file_type: [f]
+    no_group: true
+    output_file: group_name_unknown_files.txt
+  

--- a/artifacts/live_response/system/user_name_unknown_files.yaml
+++ b/artifacts/live_response/system/user_name_unknown_files.yaml
@@ -1,0 +1,218 @@
+version: 1.0
+output_directory: /live_response/system
+artifacts:
+  -
+    description: List files under / directory (no recursion, top-level only) with an unknown user ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /
+    max_depth: 1
+    file_type: [f]
+    no_user: true
+    output_file: user_name_unknown_files.txt
+  -
+    description: List files under /bin directory with an unknown user ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /bin
+    file_type: [f]
+    no_user: true
+    output_file: user_name_unknown_files.txt
+  -
+    description: List files under /sbin directory with an unknown user ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /sbin
+    file_type: [f]
+    no_user: true
+    output_file: user_name_unknown_files.txt
+  -
+    description: List files under /usr/bin directory with an unknown user ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /usr/bin
+    file_type: [f]
+    no_user: true
+    output_file: user_name_unknown_files.txt
+  -
+    description: List files under /usr/sbin directory with an unknown user ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /usr/sbin
+    file_type: [f]
+    no_user: true
+    output_file: user_name_unknown_files.txt
+  -
+    description: List files under /usr/local/bin directory with an unknown user ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /usr/local/bin
+    file_type: [f]
+    no_user: true
+    output_file: user_name_unknown_files.txt
+  -
+    description: List files under /usr/local/sbin directory with an unknown user ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /usr/local/sbin
+    file_type: [f]
+    no_user: true
+    output_file: user_name_unknown_files.txt
+  -
+    description: List files under /dev directory with an unknown user ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /dev
+    file_type: [f]
+    no_user: true
+    output_file: user_name_unknown_files.txt
+  -
+    description: List files under /etc directory with an unknown user ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /etc
+    file_type: [f]
+    no_user: true
+    output_file: user_name_unknown_files.txt
+  -
+    description: List files under /home directory (no recursion, top-level only) with an unknown user ID name.
+    supported_os: [aix, freebsd, linux, netbsd, netscaler, openbsd]
+    collector: find
+    path: /home
+    max_depth: 1
+    file_type: [f]
+    no_user: true
+    output_file: user_name_unknown_files.txt
+  -
+    description: List files under /export/home directory (no recursion, top-level only) with an unknown user ID name.
+    supported_os: [solaris]
+    collector: find
+    path: /export/home
+    max_depth: 1
+    file_type: [f]
+    no_user: true
+    output_file: user_name_unknown_files.txt
+  -
+    description: List files under /Users directory (no recursion, top-level only) with an unknown user ID name.
+    supported_os: [macos]
+    collector: find
+    path: /Users
+    max_depth: 1
+    file_type: [f]
+    no_user: true
+    output_file: user_name_unknown_files.txt
+  -
+    description: List files under user home directories (no recursion, top-level only) with an unknown user ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /%user_home%
+    max_depth: 1
+    file_type: [f]
+    no_user: true
+    exclude_nologin_users: true
+    output_file: user_name_unknown_files.txt
+  -
+    description: List files under /lib directory with an unknown user ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /lib
+    file_type: [f]
+    no_user: true
+    output_file: user_name_unknown_files.txt
+  -
+    description: List files under /lib32 directory with an unknown user ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /lib32
+    file_type: [f]
+    no_user: true
+    output_file: user_name_unknown_files.txt
+  -
+    description: List files under /lib64 directory with an unknown user ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /lib64
+    file_type: [f]
+    no_user: true
+    output_file: user_name_unknown_files.txt
+  -
+    description: List files under /usr/lib directory with an unknown user ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /usr/lib
+    file_type: [f]
+    no_user: true
+    output_file: user_name_unknown_files.txt
+  -
+    description: List files under /usr/lib32 directory with an unknown user ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /usr/lib32
+    file_type: [f]
+    no_user: true
+    output_file: user_name_unknown_files.txt
+  -
+    description: List files under /usr/lib64 directory with an unknown user ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /usr/lib64
+    file_type: [f]
+    no_user: true
+    output_file: user_name_unknown_files.txt
+  -
+    description: List files under /var/lib directory with an unknown user ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /var/lib
+    file_type: [f]
+    no_user: true
+    output_file: user_name_unknown_files.txt
+  -
+    description: List files under /run directory with an unknown user ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /run
+    file_type: [f]
+    no_user: true
+    output_file: user_name_unknown_files.txt
+  -
+    description: List files under /var/run directory with an unknown user ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /var/run
+    file_type: [f]
+    no_user: true
+    output_file: user_name_unknown_files.txt
+  -
+    description: List files under /tmp directory with an unknown user ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /tmp
+    file_type: [f]
+    no_user: true
+    output_file: user_name_unknown_files.txt
+  -
+    description: List files under /var/tmp directory with an unknown user ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /var/tmp
+    file_type: [f]
+    no_user: true
+    output_file: user_name_unknown_files.txt
+  -
+    description: List files under /run/tmp directory with an unknown user ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /run/tmp
+    file_type: [f]
+    no_user: true
+    output_file: user_name_unknown_files.txt
+  -
+    description: List files under /usr/local directory with an unknown user ID name.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    collector: find
+    path: /usr/local
+    file_type: [f]
+    no_user: true
+    output_file: user_name_unknown_files.txt
+  


### PR DESCRIPTION
Add `group_name_unknown_files.yaml` that lists files with an unknown group ID name and `user_name_unknown_files.yaml` that lists files with an unknown user ID name.