### PR TITLE
artif: update falconctl.yaml artifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ All notable changes to this project will be documented in this file.
 - `live_response/packages/snap.yaml`: Updated collection to display installed packages including all revisions [linux]. (by [Pierre-Gronau-ndaal](https://github.com/Pierre-Gronau-ndaal))
 - `live_response/packages/swupd.yaml`: Updated to list all available bundles for the current version of Clear Linux [linux]. (by [Pierre-Gronau-ndaal](https://github.com/Pierre-Gronau-ndaal))
 - `live_response/process/ps.yaml`: Updated to collect the system date before reporting a snapshot of the current processes including elapsed time since the process was started [all].
+- `live_response/system/falconctl.yaml`: Updated as `falconctl -g` is no longer a valid option [linux, macos].
 
 ### Fixed
 

--- a/artifacts/live_response/system/falconctl.yaml
+++ b/artifacts/live_response/system/falconctl.yaml
@@ -1,93 +1,27 @@
-version: 2.0
+version: 3.0
 condition: ls "/opt/CrowdStrike/falconctl" || ls /Applications/Falcon.app/Contents/Resources/falconctl
 output_directory: /live_response/system
 artifacts:
   -
-    description: Display the AgentId
+    description: Display sensor information.
     supported_os: [linux]
     collector: command
-    command: /opt/CrowdStrike/falconctl -g --aid
-    output_file: falconctl_-g_--aid.txt
+    command: /opt/CrowdStrike/falconctl info
+    output_file: falconctl_info.txt
   -
-    description: Display the CustomerId
-    supported_os: [linux]
-    collector: command
-    command: /opt/CrowdStrike/falconctl -g --cid
-    output_file: falconctl_-g_--cid.txt
-  -
-    description: Display configured sensor feature flags.
-    supported_os: [linux]
-    collector: command
-    command: /opt/CrowdStrike/falconctl -g --feature
-    output_file: falconctl_-g_--feature.txt
-  -
-    description: Display configured trace level.
-    supported_os: [linux]
-    collector: command
-    command: /opt/CrowdStrike/falconctl -g --trace
-    output_file: falconctl_-g_--trace.txt
-  -
-    description: Display if sensor is in Reduced Functionality Mode.
-    supported_os: [linux]
-    collector: command
-    command: /opt/CrowdStrike/falconctl -g --rfm-state
-    output_file: falconctl_-g_--rfm-state.txt
-  -
-    description: Display the reason for sensor running in Reduced Functionality Mode.
-    supported_os: [linux]
-    collector: command
-    command: /opt/CrowdStrike/falconctl -g --rfm-reason
-    output_file: falconctl_-g_--rfm-reason.txt
-  -
-    description: Display the currently running sensor version.
-    supported_os: [linux]
-    collector: command
-    command: /opt/CrowdStrike/falconctl -g --version
-    output_file: falconctl_-g_--version.txt
-  -
-    description: Display sensor health information.
+    description: Display sensor information and statistics.
     supported_os: [linux]
     collector: command
     command: /opt/CrowdStrike/falconctl stats
     output_file: falconctl_stats.txt
   -
-    description: Display the AgentId
+    description: Display sensor information.
     supported_os: [macos]
     collector: command
-    command: /Applications/Falcon.app/Contents/Resources/falconctl -g --aid
-    output_file: falconctl_-g_--aid.txt
+    command: /Applications/Falcon.app/Contents/Resources/falconctl info
+    output_file: falconctl_info.txt
   -
-    description: Display the CustomerId
-    supported_os: [macos]
-    collector: command
-    command: /Applications/Falcon.app/Contents/Resources/falconctl -g --cid
-    output_file: falconctl_-g_--cid.txt
-  -
-    description: Display configured sensor feature flags.
-    supported_os: [macos]
-    collector: command
-    command: /Applications/Falcon.app/Contents/Resources/falconctl -g --feature
-    output_file: falconctl_-g_--feature.txt
-  -
-    description: Display configured trace level.
-    supported_os: [macos]
-    collector: command
-    command: /Applications/Falcon.app/Contents/Resources/falconctl -g --trace
-    output_file: falconctl_-g_--trace.txt
-  -
-    description: Display if sensor is in Reduced Functionality Mode.
-    supported_os: [macos]
-    collector: command
-    command: /Applications/Falcon.app/Contents/Resources/falconctl -g --rfm-state
-    output_file: falconctl_-g_--rfm-state.txt
-  -
-    description: Display the reason for sensor running in Reduced Functionality Mode.
-    supported_os: [macos]
-    collector: command
-    command: /Applications/Falcon.app/Contents/Resources/falconctl -g --rfm-reason
-    output_file: falconctl_-g_--rfm-reason.txt
-  -
-    description: Display sensor health information.
+    description: Display sensor information and statistics.
     supported_os: [macos]
     collector: command
     command: /Applications/Falcon.app/Contents/Resources/falconctl stats


### PR DESCRIPTION
Updated as `falconctl -g` is no longer a valid option.