### PR TITLE
refactor: remove LD_PRELOAD

### DIFF
--- a/uac
+++ b/uac
@@ -5,6 +5,9 @@
 # remove all existing aliases
 \unalias -a
 
+# remove LD_PRELOAD environment variable
+unset LD_PRELOAD
+
 # set locale
 LANG=C
 export LANG


### PR DESCRIPTION
Remove the LD_PRELOAD environment variable at the start of the UAC main script.
Doing so allows UAC to run without interference from rootkits loaded via the LD_PRELOAD environment variable.
