### PR TITLE
Get loginctl info from all users, not just the one doing the collection

### DIFF
--- a/artifacts/live_response/system/loginctl.yaml
+++ b/artifacts/live_response/system/loginctl.yaml
@@ -6,5 +6,6 @@ artifacts:
     description: Show terse runtime status information about one or more logged in users, followed by the most recent log data from the journal.
     supported_os: [linux]
     collector: command
-    command: loginctl user-status
+    foreach: loginctl list-users | tail -n +2 | head -n -2 | awk '{print $2}'
+    command: loginctl user-status %line%
     output_file: loginctl_user-status.txt

--- a/artifacts/live_response/system/loginctl.yaml
+++ b/artifacts/live_response/system/loginctl.yaml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 3.0
 condition: command_exists "loginctl"
 output_directory: /live_response/system
 artifacts:
@@ -6,6 +6,6 @@ artifacts:
     description: Show terse runtime status information about one or more logged in users, followed by the most recent log data from the journal.
     supported_os: [linux]
     collector: command
-    foreach: loginctl list-users | tail -n +2 | head -n -2 | awk '{print $2}'
-    command: loginctl user-status %line%
-    output_file: loginctl_user-status.txt
+    command: loginctl user-status %user%
+    output_file: loginctl_user-status_%user%.txt
+    exclude_nologin_users: true

--- a/profiles/offline_ir_triage.yaml
+++ b/profiles/offline_ir_triage.yaml
@@ -4,8 +4,15 @@ artifacts:
   - bodyfile/bodyfile.yaml
   - chkrootkit/*
   - hash_executables/hash_executables.yaml
+  - live_response/packages/*
+  - live_response/system/immutable_files.yaml
+  - live_response/system/hidden_files.yaml
+  - live_response/system/hidden_directories.yaml
+  - live_response/system/sgid.yaml
+  - live_response/system/suid.yaml
   - files/applications/git.yaml
   - files/applications/lesshst.yaml
+  - files/applications/nano.yaml
   - files/applications/viminfo.yaml
   - files/applications/wget.yaml
   - files/logs/*


### PR DESCRIPTION
From the loginctl manpage 

```If no parameters are passed, the status is shown for the user of the session of the caller.```

So, this will get info for all the active users, by first running `loginctl list-users` and then running `loginctl user-status` for each one.