### PR TITLE
artif: add disable_ftrace modifier for live response artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `live_response/modifiers/disable_ftrace.yaml`: Added modifier to disable ftrace to prevent syscall hooking by LKM rootkits [linux]. (by [mnrkbys](https://github.com/mnrkbys))
+
 ### Changed
 
 ### Fixed

--- a/artifacts/live_response/modifiers/disable_ftrace.yaml
+++ b/artifacts/live_response/modifiers/disable_ftrace.yaml
@@ -1,0 +1,19 @@
+version: 1.0
+modifier: true
+output_directory: /live_response/modifiers
+artifacts:
+  -
+    description: Display kernel parameters before changing the system state.
+    supported_os: [linux]
+    collector: command
+    command: sysctl -a
+    output_file: sysctl_-a.txt
+  -
+    description: Disable ftrace to prevent syscall hooking by LKM rootkits.
+    supported_os: [linux]
+    collector: command
+    command: sysctl kernel.ftrace_enabled=0
+    output_file: sysctl_disable_ftrace.txt
+
+# References:
+# https://tmpout.sh/4/10.html


### PR DESCRIPTION
Modern LKM rootkits use ftrace to hook syscalls.
So, disabling ftrace would be beneficial for UAC.
This PR is related to #352.