### PR TITLE
artif: move offline artifacts out of live_response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,17 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- `live_response/packages/slackpkg.yaml`: Moved to `packages/slackpkg.yaml`.
+- `live_response/system/group_name_unknown_files.yaml`: Moved to `system/group_name_unknown_files.yaml`.
+- `live_response/system/hidden_directories.yaml`: Moved to `system/hidden_directories.yaml`.
+- `live_response/system/hidden_files.yaml`: Moved to `system/hidden_files.yaml`.
+- `live_response/system/immutable_files.yaml`: Moved to `system/immutable_files.yaml`.
 - `live_response/system/loginctl.yaml`: Added terse runtime status information collection for each user in the system [linux]. (by [clausing](https://github.com/clausing))
+- `live_response/system/sgid.yaml`: Moved to `system/sgid.yaml`.
+- `live_response/system/suid.yaml`: Moved to `system/suid.yaml`.
+- `live_response/system/user_name_known_files.yaml`: Moved to `system/user_name_known_files.yaml`.
+- `live_response/system/world_writable_directories.yaml`: Moved to `system/world_writable_directories.yaml`.
+- `live_response/system/world_writable_files.yaml`: Moved to `system/world_writable_files.yaml`.
 
 ### Fixed
 

--- a/artifacts/packages/slackpkg.yaml
+++ b/artifacts/packages/slackpkg.yaml
@@ -1,6 +1,6 @@
-version: 1.0
+version: 1.1
 condition: command_exists "slackpkg"
-output_directory: /live_response/packages
+output_directory: /packages
 artifacts:
   -
     description: Display installed and upgradable packages.

--- a/artifacts/system/group_name_unknown_files.yaml
+++ b/artifacts/system/group_name_unknown_files.yaml
@@ -1,5 +1,5 @@
-version: 1.0
-output_directory: /live_response/system
+version: 1.1
+output_directory: /system
 artifacts:
   -
     description: List files under / directory (no recursion, top-level only) with an unknown group ID name.

--- a/artifacts/system/hidden_directories.yaml
+++ b/artifacts/system/hidden_directories.yaml
@@ -1,5 +1,5 @@
-version: 2.0
-output_directory: /live_response/system
+version: 2.1
+output_directory: /system
 artifacts:
   -
     description: List all hidden directories outside of user home directory.

--- a/artifacts/system/hidden_files.yaml
+++ b/artifacts/system/hidden_files.yaml
@@ -1,5 +1,5 @@
-version: 2.0
-output_directory: /live_response/system
+version: 2.1
+output_directory: /system
 artifacts:
   -
     description: List all hidden files outside of user home directory.

--- a/artifacts/system/immutable_files.yaml
+++ b/artifacts/system/immutable_files.yaml
@@ -1,6 +1,6 @@
-version: 1.0
+version: 1.1
 condition: command_exists "lsattr"
-output_directory: /live_response/system
+output_directory: /system
 artifacts:
   -
     description: List immutable files under / directory (no recursion, top-level only).

--- a/artifacts/system/sgid.yaml
+++ b/artifacts/system/sgid.yaml
@@ -1,5 +1,5 @@
-version: 2.0
-output_directory: /live_response/system
+version: 2.1
+output_directory: /system
 artifacts:
   -
     description: Search for files that have SGID bit set.

--- a/artifacts/system/suid.yaml
+++ b/artifacts/system/suid.yaml
@@ -1,5 +1,5 @@
-version: 2.0
-output_directory: /live_response/system
+version: 2.1
+output_directory: /system
 artifacts:
   -
     description: Search for files that have SUID bit set.

--- a/artifacts/system/user_name_unknown_files.yaml
+++ b/artifacts/system/user_name_unknown_files.yaml
@@ -1,5 +1,5 @@
-version: 1.0
-output_directory: /live_response/system
+version: 1.1
+output_directory: /system
 artifacts:
   -
     description: List files under / directory (no recursion, top-level only) with an unknown user ID name.

--- a/artifacts/system/world_writable_directories.yaml
+++ b/artifacts/system/world_writable_directories.yaml
@@ -1,5 +1,5 @@
-version: 2.0
-output_directory: /live_response/system
+version: 2.1
+output_directory: /system
 artifacts:
   -
     description: List all world writable directories.

--- a/artifacts/system/world_writable_files.yaml
+++ b/artifacts/system/world_writable_files.yaml
@@ -1,5 +1,5 @@
-version: 2.0
-output_directory: /live_response/system
+version: 2.1
+output_directory: /system
 artifacts:
   -
     description: List all world writable files.

--- a/profiles/full.yaml
+++ b/profiles/full.yaml
@@ -26,6 +26,8 @@ artifacts:
   - live_response/vms/*
   - chkrootkit/*
   - hash_executables/hash_executables.yaml
+  - system/*
+  - packages/*
   - osquery/osquery.yaml
   - files/*
   

--- a/profiles/ir_triage.yaml
+++ b/profiles/ir_triage.yaml
@@ -26,9 +26,12 @@ artifacts:
   - live_response/vms/*
   - chkrootkit/*
   - hash_executables/hash_executables.yaml
+  - system/*
+  - packages/*
   - osquery/osquery.yaml
   - files/applications/git.yaml
   - files/applications/lesshst.yaml
+  - files/applications/nano.yaml
   - files/applications/viminfo.yaml
   - files/applications/wget.yaml
   - files/logs/*

--- a/profiles/offline.yaml
+++ b/profiles/offline.yaml
@@ -4,4 +4,6 @@ artifacts:
   - bodyfile/bodyfile.yaml
   - chkrootkit/*
   - hash_executables/hash_executables.yaml
+  - system/*
+  - packages/*
   - files/*

--- a/profiles/offline_ir_triage.yaml
+++ b/profiles/offline_ir_triage.yaml
@@ -4,12 +4,8 @@ artifacts:
   - bodyfile/bodyfile.yaml
   - chkrootkit/*
   - hash_executables/hash_executables.yaml
-  - live_response/packages/*
-  - live_response/system/immutable_files.yaml
-  - live_response/system/hidden_files.yaml
-  - live_response/system/hidden_directories.yaml
-  - live_response/system/sgid.yaml
-  - live_response/system/suid.yaml
+  - system/*
+  - packages/*
   - files/applications/git.yaml
   - files/applications/lesshst.yaml
   - files/applications/nano.yaml


### PR DESCRIPTION
Move artifacts that can also be used offline out of the live_response directory.

Issue #362 