### PR TITLE
fix: issue with ssh options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,12 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fixed a bug where the global `max_depth` set in uac.conf was not being respected in some cases. ([#359](https://github.com/tclahr/uac/issues/359))
+- Fixed a bug where sftp ssh options were not being set correctly. ([#366](https://github.com/tclahr/uac/issues/366))
 
 ### Profiles
+
+### Command Line Option Changes
+
+- `--sftp-ssh-options` is now `--sftp-ssh-option`: This allows setting SSH options as key=value pairs. Can be used multiple times to set multiple options. ([#366](https://github.com/tclahr/uac/issues/366))
 
 ### New Artifact Properties

--- a/lib/parse_command_line_arguments.sh
+++ b/lib/parse_command_line_arguments.sh
@@ -248,9 +248,9 @@ _parse_command_line_arguments()
           return 1
         fi
         ;;
-      "--sftp-ssh-options")
+      "--sftp-ssh-option")
         if [ -n "${2:-}" ]; then
-          __UAC_SFTP_SSH_OPTIONS="${2}"
+          __UAC_SFTP_SSH_OPTIONS="${__UAC_SFTP_SSH_OPTIONS} -o ${2}"
           shift
         else
           _error_msg "option '${1}' requires an argument.\nTry 'uac --help' for more information."

--- a/lib/sftp_transfer.sh
+++ b/lib/sftp_transfer.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # SPDX-License-Identifier: Apache-2.0
+# shellcheck disable=SC2317
 
 # Transfer file to SFTP server.
 # Arguments:
@@ -8,7 +9,7 @@
 #   string destination: destination in the form [user@]host:[path]
 #   integer port: port number
 #   string identity_file: identity file path
-#   string ssh_options: comma separated ssh options
+#   string ssh_options: ssh options
 # Returns:
 #   boolean: true on success
 #            false on fail
@@ -20,24 +21,22 @@ _sftp_transfer()
   __sr_identity_file="${4:-}"
   __sr_ssh_options="${5:-}"
 
-  __sr_port_param="-P ${__sr_port}"
-  __sr_ssh_options_param="-o StrictHostKeyChecking=no,UserKnownHostsFile=/dev/null${__sr_ssh_options:+,}${__sr_ssh_options}"
-  __sr_identity_file_param="${__sr_identity_file:+-i }\"${__sr_identity_file}\""
-
+  __sr_command="sftp -r -P ${__sr_port}"
+  if [ -n "${__sr_identity_file}" ]; then
+    __sr_command="${__sr_command} -i \"${__sr_identity_file}\""
+  fi
+  __sr_command="${__sr_command} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+  
+  if [ -n "${__sr_ssh_options}" ]; then
+    __sr_command="${__sr_command}${__sr_ssh_options}"
+  fi
+  
   if [ -n "${__sr_source}" ]; then
-    __sr_command="sftp -r \
-${__sr_port_param} \
-${__sr_identity_file_param} \
-${__sr_ssh_options_param} \
-\"${__sr_destination}\" >/dev/null << EOF
+    __sr_command="${__sr_command} \"${__sr_destination}\" >/dev/null << EOF
 mput \"${__sr_source}\"
 EOF"
   else
-    __sr_command="sftp -r \
-${__sr_port_param} \
-${__sr_identity_file_param} \
-${__sr_ssh_options_param} \
-\"${__sr_destination}\" >/dev/null << EOF
+    __sr_command="${__sr_command} \"${__sr_destination}\" >/dev/null << EOF
 pwd
 EOF"
   fi

--- a/lib/usage.sh
+++ b/lib/usage.sh
@@ -101,8 +101,9 @@ Remote Transfer Arguments:
       --sftp-identity-file FILE
                     File from which the identity (private key) for public key
                     authentication is read.
-      --sftp-ssh-options
-                    Comma separated ssh options.
+      --sftp-ssh-option
+                    Allow setting SSH options as key=value pairs.
+                    Can be used multiple times to set multiple options.
       --s3-provider
                     Transfer the output and log files to S3 service.
                     Options: amazon, google, ibm


### PR DESCRIPTION
Fixes bug where sftp ssh options were not being set correctly. Fix #366

This PR also changes the command line option:

`--sftp-ssh-options` is now `--sftp-ssh-option`: This allows setting SSH options as key=value pairs. Can be used multiple times to set multiple options.

