### PR TITLE
artif: update getcap.yaml to skip non-local mounts

### DIFF
--- a/.github/workflows/unit-testing.yaml
+++ b/.github/workflows/unit-testing.yaml
@@ -6,6 +6,7 @@ on:
       - develop
       - main
     paths:
+      - 'bin/linux/**'
       - 'lib/**'
       - 'uac'
       
@@ -41,4 +42,4 @@ jobs:
       - name: Run tests
         working-directory: ushunit
         run: |
-          UAC_DIR="../uac" ./ushunit -i ../uac-tests/tests/lib/*.sh ../uac-tests/tests/*.sh
+          UAC_DIR="../uac" ./ushunit -i ../uac-tests/tests/bin/linux/*.sh ../uac-tests/tests/lib/*.sh ../uac-tests/tests/*.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to this project will be documented in this file.
 - `live_response/modifiers/disable_ftrace.yaml`: Added modifier to disable ftrace to prevent syscall hooking by LKM rootkits [linux]. (by [mnrkbys](https://github.com/mnrkbys))
 - `live_response/packages/slackpkg.yaml`: Moved to `packages/slackpkg.yaml`.
 - `live_response/process/procfs_information.yaml`: Added collection of /proc/modules [aix, freebsd, linux, netbsd, netscaler, solaris]. (by [SolitudePy](https://github.com/SolitudePy))
+- `live_response/system/getcap.yaml`: Moved to `system/getcap.yaml`. Updated to skip non-local file systems [linux]. ([#375](https://github.com/tclahr/uac/issues/375))
 - `live_response/system/group_name_unknown_files.yaml`: Moved to `system/group_name_unknown_files.yaml`.
 - `live_response/system/hidden_directories.yaml`: Moved to `system/hidden_directories.yaml`.
 - `live_response/system/hidden_files.yaml`: Moved to `system/hidden_files.yaml`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.  
+All notable changes to this project will be documented in this file.
 
 ## DEVELOPMENT VERSION
 
@@ -40,7 +40,7 @@ All notable changes to this project will be documented in this file.
 - `live_response/system/group_name_unknown_files.yaml`: Moved to `system/group_name_unknown_files.yaml`.
 - `live_response/system/hidden_directories.yaml`: Moved to `system/hidden_directories.yaml`.
 - `live_response/system/hidden_files.yaml`: Moved to `system/hidden_files.yaml`.
-- `live_response/system/immutable_files.yaml`: Moved to `system/immutable_files.yaml`.
+- `live_response/system/immutable_files.yaml`: Moved to `system/immutable_files.yaml`. Updated to skip non-local file systems [linux].
 - `live_response/system/loginctl.yaml`: Added terse runtime status information collection for each user in the system [linux]. (by [clausing](https://github.com/clausing))
 - `live_response/system/sgid.yaml`: Moved to `system/sgid.yaml`.
 - `live_response/system/suid.yaml`: Moved to `system/suid.yaml`.

--- a/artifacts/system/getcap.yaml
+++ b/artifacts/system/getcap.yaml
@@ -8,6 +8,6 @@ artifacts:
     description: List files that have process capabilities.
     supported_os: [linux]
     collector: command
-    foreach: getcap_wrapper.sh "%mount_point%" "/dev|/proc|/run|/sys|%non_local_mount_points%"
+    foreach: getcap_wrapper.sh "%mount_point%" "/proc|/sys|%non_local_mount_points%"
     command: %line%
     output_file: getcap.txt

--- a/artifacts/system/getcap.yaml
+++ b/artifacts/system/getcap.yaml
@@ -1,6 +1,6 @@
-version: 1.0
+version: 2.0
 condition: command_exists "getcap"
-output_directory: /live_response/system
+output_directory: /system
 # abuse process capabilities
 # ref: https://www.elastic.co/security-labs/sequel-on-persistence-mechanisms
 artifacts:
@@ -8,6 +8,6 @@ artifacts:
     description: List files that have process capabilities.
     supported_os: [linux]
     collector: command
-    foreach: ls -d /* | grep -vE '^/(proc|sys|dev|boot|run|swapfile)$'
-    command: getcap -r "%line%"/*
-    output_file: getcap_-r.txt
+    foreach: getcap_wrapper.sh "%mount_point%" "/dev|/proc|/run|/sys|%non_local_mount_points%"
+    command: %line%
+    output_file: getcap.txt

--- a/artifacts/system/immutable_files.yaml
+++ b/artifacts/system/immutable_files.yaml
@@ -1,59 +1,11 @@
-version: 1.1
+version: 2.0
 condition: command_exists "lsattr"
 output_directory: /system
 artifacts:
   -
-    description: List immutable files under / directory (no recursion, top-level only).
+    description: List immutable files.
     supported_os: [linux]
     collector: command
-    command: lsattr / | awk '{if ($1 ~ /i/ && $1 !~ /^\\//) print $0}'
-    output_file: immutable_files.txt
-  -
-    description: List immutable files under system binary directories (recursively).
-    supported_os: [linux]
-    collector: command
-    command: lsattr -R /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin | awk '{if ($1 ~ /i/ && $1 !~ /^\\//) print $0}'
-    output_file: immutable_files.txt
-  -
-    description: List immutable files under /dev directory (recursively).
-    supported_os: [linux]
-    collector: command
-    command: lsattr -R /dev | awk '{if ($1 ~ /i/ && $1 !~ /^\\//) print $0}'
-    output_file: immutable_files.txt
-  -
-    description: List immutable files under /etc directory (recursively).
-    supported_os: [linux]
-    collector: command
-    command: lsattr -R /etc | awk '{if ($1 ~ /i/ && $1 !~ /^\\//) print $0}'
-    output_file: immutable_files.txt
-  -
-    description: List immutable files under user home directories (no recursion, top-level only).
-    supported_os: [linux]
-    collector: command
-    command: lsattr /%user_home% /%user_home%/.ssh /%user_home%/.*history | awk '{if ($1 ~ /i/ && $1 !~ /^\\//) print $0}'
-    exclude_nologin_users: true
-    output_file: immutable_files.txt
-  -
-    description: List immutable files under system library directories (recursively).
-    supported_os: [linux]
-    collector: command
-    command: lsattr -R /lib /lib32 /lib64 /usr/lib /usr/lib32 /usr/lib64 /var/lib | awk '{if ($1 ~ /i/ && $1 !~ /^\\//) print $0}'
-    output_file: immutable_files.txt
-  -
-    description: List immutable files under /run directories (recursively).
-    supported_os: [linux]
-    collector: command
-    command: lsattr -R /run /var/run | awk '{if ($1 ~ /i/ && $1 !~ /^\\//) print $0}'
-    output_file: immutable_files.txt
-  -
-    description: List immutable files under /tmp directories (recursively).
-    supported_os: [linux]
-    collector: command
-    command: lsattr -R /tmp /var/tmp /run/tmp | awk '{if ($1 ~ /i/ && $1 !~ /^\\//) print $0}'
-    output_file: immutable_files.txt
-  -
-    description: List immutable files under /user/local directories (recursively).
-    supported_os: [linux]
-    collector: command
-    command: lsattr -R /usr/local | awk '{if ($1 ~ /i/ && $1 !~ /^\\//) print $0}'
+    foreach: lsattr_wrapper.sh "%mount_point%" "/proc|/sys|%non_local_mount_points%"
+    command: %line% | awk '{if ($1 ~ /i/ && $1 !~ /^\\//) print $0}'
     output_file: immutable_files.txt

--- a/bin/linux/getcap_wrapper.sh
+++ b/bin/linux/getcap_wrapper.sh
@@ -3,7 +3,7 @@
 # shellcheck disable=SC2006
 
 _usage() {
-  printf "%s" "Usage: $0 MOUNT_POINT [EXCLUDE_PATHS]
+  printf "%s" "Usage: getcap_wrapper.sh MOUNT_POINT [EXCLUDE_PATHS]
   
 Recursively scans a local directory tree and prints 'getcap' commands
 without executing them, while allowing exclusion of specified paths
@@ -14,7 +14,7 @@ Arguments:
   EXCLUDE_PATHS    Pipe-separated list of paths to exclude (e.g. /proc|/sys|/dev)
 
 Example:
-  $0 / \"/proc|/sys|/dev\"
+  getcap_wrapper.sh / \"/proc|/sys|/dev\"
 "
 }
 
@@ -80,7 +80,7 @@ while [ ${#} -gt 0 ]; do
       elif [ -z "${__gc_exclude_paths}" ]; then
         __gc_exclude_paths="${1}"
       else
-        printf "invalid option '%s'\nTry '%s --help' for more information.\n" "${1}" "$0" >&2
+        printf "invalid option '%s'\nTry 'getcap_wrapper.sh --help' for more information.\n" "${1}" >&2
         return 1
       fi
       ;;
@@ -97,7 +97,7 @@ if [ -z "${__gc_mount_point}" ]; then
 fi
 
 if [ ! -d "${__gc_mount_point}" ]; then
-  printf "%s: cannot access '%s': No such file or directory\n" "$0" "${__gc_mount_point}" >&2
+  printf "getcap_wrapper.sh: cannot access '%s': No such file or directory\n" "${__gc_mount_point}" >&2
   exit 1
 fi
 

--- a/bin/linux/getcap_wrapper.sh
+++ b/bin/linux/getcap_wrapper.sh
@@ -1,0 +1,104 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+# shellcheck disable=SC2006
+
+_usage() {
+  printf "%s" "Usage: $0 MOUNT_POINT [EXCLUDE_PATHS]
+  
+Recursively scans a local directory tree and prints 'getcap' commands
+without executing them, while allowing exclusion of specified paths
+to avoid non-local mounts.
+
+Arguments:
+  MOUNT_POINT      Base directory to start scanning
+  EXCLUDE_PATHS    Pipe-separated list of paths to exclude (e.g. /proc|/sys|/dev)
+
+Example:
+  $0 / \"/proc|/sys|/dev\"
+"
+}
+
+_recurse_dir() {
+  __rd_base_dir="${1:-}"
+  __rd_exclude_paths="${2:-}"
+
+  printf "getcap \"%s\"/*\n" "${__rd_base_dir}"
+
+  for __rd_entry in "${__rd_base_dir}"/*; do
+    if [ ! -d "${__rd_entry}" ]; then
+      continue
+    fi
+
+    # Normalize leading slashes
+    case "${__rd_entry}" in
+      //*) __rd_entry="/`echo "${__rd_entry}" | sed 's|^//*||'`" ;;
+    esac
+
+    __rd_skip_dir=false
+
+    __rd_OIFS=${IFS}
+    IFS='|'
+    for __rd_exclude in ${__rd_exclude_paths}; do
+      if [ "${__rd_entry}" = "${__rd_exclude}" ]; then
+        __rd_skip_dir=true
+        break
+      fi
+      case "${__rd_exclude}" in
+        "${__rd_entry}/"*)
+          # recurse if exclude is under entry
+          (
+            _recurse_dir "${__rd_entry}" "${__rd_exclude_paths}"
+          )
+          __rd_skip_dir=true
+          break
+          ;;
+      esac
+    done
+    IFS=${__rd_OIFS}
+
+    if [ "${__rd_skip_dir}" = false ]; then
+      printf "getcap -r \"%s\"/*\n" "${__rd_entry}"
+    fi
+
+  done
+
+}
+
+__gc_mount_point=""
+__gc_exclude_paths=""
+
+while [ ${#} -gt 0 ]; do
+  case "${1}" in
+    # optional arguments
+    "-h"|"--help")
+      _usage
+      exit 0
+      ;;
+    *)
+      if [ -z "${__gc_mount_point}" ]; then
+        __gc_mount_point="${1}"
+      elif [ -z "${__gc_exclude_paths}" ]; then
+        __gc_exclude_paths="${1}"
+      else
+        printf "invalid option '%s'\nTry '%s --help' for more information.\n" "${1}" "$0" >&2
+        return 1
+      fi
+      ;;
+  esac
+  shift
+done
+
+# do not allow using undefined variables
+set -u
+
+if [ -z "${__gc_mount_point}" ]; then
+  _usage
+  exit 1
+fi
+
+if [ ! -d "${__gc_mount_point}" ]; then
+  printf "%s: cannot access '%s': No such file or directory\n" "$0" "${__gc_mount_point}" >&2
+  exit 1
+fi
+
+_recurse_dir "${__gc_mount_point}" "${__gc_exclude_paths}"

--- a/bin/linux/lsattr_wrapper.sh
+++ b/bin/linux/lsattr_wrapper.sh
@@ -3,9 +3,9 @@
 # shellcheck disable=SC2006
 
 _usage() {
-  printf "%s" "Usage: getcap_wrapper.sh MOUNT_POINT [EXCLUDE_PATHS]
+  printf "%s" "Usage: lsattr_wrapper.sh MOUNT_POINT [EXCLUDE_PATHS]
   
-Recursively scans a local directory tree and prints 'getcap' commands
+Recursively scans a local directory tree and prints 'lsattr' commands
 without executing them, while allowing exclusion of specified paths
 to avoid non-local mounts.
 
@@ -14,7 +14,7 @@ Arguments:
   EXCLUDE_PATHS    Pipe-separated list of paths to exclude (e.g. /proc|/sys|/dev)
 
 Example:
-  getcap_wrapper.sh / \"/proc|/sys|/dev\"
+  lsattr_wrapper.sh / \"/proc|/sys|/dev\"
 "
 }
 
@@ -39,7 +39,7 @@ _recurse_dir() {
   __rd_base_dir="${1:-}"
   __rd_exclude_paths="${2:-}"
 
-  printf "getcap \"%s\"/*\n" "${__rd_base_dir}"
+  printf "lsattr \"%s\"\n" "${__rd_base_dir}"
 
   for __rd_entry in "${__rd_base_dir}"/*; do
     if [ ! -d "${__rd_entry}" ]; then
@@ -73,7 +73,7 @@ _recurse_dir() {
     IFS=${__rd_OIFS}
 
     if [ "${__rd_skip_dir}" = false ]; then
-      printf "getcap -r \"%s\"/*\n" "${__rd_entry}"
+      printf "lsattr -R \"%s\"\n" "${__rd_entry}"
     fi
 
   done
@@ -95,7 +95,7 @@ while [ ${#} -gt 0 ]; do
       elif [ -z "${__gc_exclude_paths}" ]; then
         __gc_exclude_paths="${1}"
       else
-        printf "invalid option '%s'\nTry 'getcap_wrapper.sh --help' for more information.\n" "${1}" >&2
+        printf "invalid option '%s'\nTry 'lsattr_wrapper.sh --help' for more information.\n" "${1}" >&2
         return 1
       fi
       ;;
@@ -112,7 +112,7 @@ if [ -z "${__gc_mount_point}" ]; then
 fi
 
 if [ ! -d "${__gc_mount_point}" ]; then
-  printf "getcap_wrapper.sh: cannot access '%s': No such file or directory\n" "${__gc_mount_point}" >&2
+  printf "lsattr_wrapper.sh: cannot access '%s': No such file or directory\n" "${__gc_mount_point}" >&2
   exit 1
 fi
 

--- a/lib/parse_artifact.sh
+++ b/lib/parse_artifact.sh
@@ -66,6 +66,7 @@ _parse_artifact()
     printf "%s" "${__re_value}" \
       | sed -e "s|%uac_directory%|${__UAC_DIR}|g" \
             -e "s|%mount_point%|${__UAC_MOUNT_POINT}|g" \
+            -e "s:%non_local_mount_points%:${__UAC_EXCLUDE_MOUNT_POINTS}:g" \
             -e "s|%temp_directory%|${__UAC_TEMP_DATA_DIR}/tmp|g" 2>/dev/null
   }
 


### PR DESCRIPTION
Updated getcap.yaml to skip non-local mounts using getcap_wrapper.sh tool.

Fixes #375 