### PR TITLE
fix: prevent lshw from hanging

### DIFF
--- a/artifacts/live_response/hardware/lshw.yaml
+++ b/artifacts/live_response/hardware/lshw.yaml
@@ -6,5 +6,5 @@ artifacts:
     description: Display hardware information.
     supported_os: [linux]
     collector: command
-    command: lshw
+    command: timeout -k 45s 30s lshw
     output_file: lshw.txt


### PR DESCRIPTION
Wrap lshw with a timeout command (from GNU coreutils) to prevent it from hanging the entire artifacts collection process. The timeout values were selected just as some sane values.
Resolves #380 