### PR TITLE
fix load custom config file order

### DIFF
--- a/lib/parse_command_line_arguments.sh
+++ b/lib/parse_command_line_arguments.sh
@@ -103,7 +103,7 @@ _parse_command_line_arguments()
       # collection arguments
       "-c"|"--config")
           if [ -n "${2:-}" ]; then
-            __UAC_CONFIG_FILE="${2}"
+            __UAC_CUSTOM_CONFIG_FILE="${2}"
             shift
           else
             _error_msg "option '${1}' requires an argument.\nTry 'uac --help' for more information."

--- a/lib/usage.sh
+++ b/lib/usage.sh
@@ -53,7 +53,7 @@ Output Arguments:
 
 Collection Arguments:
   -c, --config      FILE
-                    Load the config from a specific file.
+                    Load config from a specific file.
   -m, --mount-point MOUNT_POINT
                     Specify the mount point (default: /).
   -s, --operating-system OPERATING_SYSTEM

--- a/uac
+++ b/uac
@@ -62,6 +62,7 @@ __UAC_OUTPUT_EXTENSION=""
 __UAC_OUTPUT_PASSWORD=""
 __UAC_HASH_COLLECTED=false
 __UAC_CONFIG_FILE="${__UAC_DIR}/config/uac.conf"
+__UAC_CUSTOM_CONFIG_FILE=""
 __UAC_MOUNT_POINT="/"
 __UAC_OPERATING_SYSTEM=""
 __UAC_ENABLE_MODIFIERS=false
@@ -164,6 +165,13 @@ _load_config_file "${__UAC_CONFIG_FILE}" || _exit_fatal
 if [ -f "${__UAC_DIR}/config/${__UAC_OPERATING_SYSTEM}.conf" ]; then
   _verbose_msg "Loading ${__UAC_OPERATING_SYSTEM}.conf..."
   _load_config_file "${__UAC_DIR}/config/${__UAC_OPERATING_SYSTEM}.conf" || _exit_fatal
+fi
+if [ -n "${__UAC_CUSTOM_CONFIG_FILE}" ]; then
+  if [ ! -f "${__UAC_CUSTOM_CONFIG_FILE}" ]; then
+    _exit_fatal "no such config file '${__UAC_CUSTOM_CONFIG_FILE}'"
+  fi
+  _verbose_msg "Loading ${__UAC_CUSTOM_CONFIG_FILE}..."
+  _load_config_file "${__UAC_CUSTOM_CONFIG_FILE}" || _exit_fatal
 fi
 
 # add proper local 'bin' directory to path


### PR DESCRIPTION
Load custom config file provided by -c/--config after loading uac.conf and [os].conf.