### PR TITLE
Update ss.yaml to show bpf filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,6 @@ All notable changes to this project will be documented in this file.
 
 ### Artifacts
 
+- `live_response/network/ss.yaml`: Updated to show PACKET sockets, socket classic BPF filters, and show the process name and PID of the program to which socket belongs [linux]. (by [ekt0-syn](https://github.com/ekt0-syn))
+
 ### Fixed

--- a/artifacts/live_response/network/ss.yaml
+++ b/artifacts/live_response/network/ss.yaml
@@ -63,7 +63,6 @@ artifacts:
     command: ss -ulnp
     output_file: ss_-ulnp.txt
   -
-
     description: Display PACKET sockets, show socket classic BPF filters, and show the process name and PID of the program to which socket belongs.
     supported_os: [linux]
     collector: command

--- a/artifacts/live_response/network/ss.yaml
+++ b/artifacts/live_response/network/ss.yaml
@@ -62,3 +62,10 @@ artifacts:
     collector: command
     command: ss -ulnp
     output_file: ss_-ulnp.txt
+  -
+
+    description: Display PACKET sockets, show socket classic BPF filters, and show the process name and PID of the program to which socket belongs.
+    supported_os: [linux]
+    collector: command
+    command: ss -0bp
+    output_file: ss_-0bp.txt


### PR DESCRIPTION
Detect running processes that inserted BPF filters in the Linux server

Example: https://www.trendmicro.com/en_us/research/23/g/detecting-bpfdoor-backdoor-variants-abusing-bpf-filters.html