### PR TITLE
artif: add binfmt_misc artifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Artifacts
 
 - `live_response/network/ss.yaml`: Updated to show PACKET sockets, socket classic BPF filters, and show the process name and PID of the program to which socket belongs [linux]. (by [ekt0-syn](https://github.com/ekt0-syn))
+- `live_response/system/binfmt_misc`: Added collection of binfmt_misc handlers [linux]. (by [mnrkbys](https://github.com/mnrkbys))
 
 ### Fixed
 

--- a/artifacts/live_response/system/binfmt_misc.yaml
+++ b/artifacts/live_response/system/binfmt_misc.yaml
@@ -1,0 +1,17 @@
+version: 1.0
+output_directory: /live_response/system
+artifacts:
+  -
+    description: Collect binfmt_misc files.
+    supported_os: [linux]
+    collector: command
+    foreach: ls -a /proc/sys/fs/binfmt_misc | grep -vE '^(\.\.?|register|status)$'
+    command: cat /proc/sys/fs/binfmt_misc/%line%
+    output_directory: /live_response/system/binfmt_misc
+    output_file: binfmt_misc_%line%.txt
+
+# References:
+# https://dfir.ch/posts/today_i_learned_binfmt_misc/
+# https://www.sentinelone.com/blog/shadow-suid-for-privilege-persistence-part-1/
+# https://www.sentinelone.com/blog/shadow-suid-privilege-persistence-part-2/
+

--- a/artifacts/live_response/system/binfmt_misc.yaml
+++ b/artifacts/live_response/system/binfmt_misc.yaml
@@ -8,10 +8,9 @@ artifacts:
     foreach: ls -a /proc/sys/fs/binfmt_misc | grep -vE '^(\.\.?|register|status)$'
     command: cat /proc/sys/fs/binfmt_misc/%line%
     output_directory: /live_response/system/binfmt_misc
-    output_file: binfmt_misc_%line%.txt
+    output_file: %line%.txt
 
 # References:
 # https://dfir.ch/posts/today_i_learned_binfmt_misc/
 # https://www.sentinelone.com/blog/shadow-suid-for-privilege-persistence-part-1/
 # https://www.sentinelone.com/blog/shadow-suid-privilege-persistence-part-2/
-


### PR DESCRIPTION
The Linux binfmt_misc may cause privilege escalation.

References:
https://dfir.ch/posts/today_i_learned_binfmt_misc/
https://www.sentinelone.com/blog/shadow-suid-for-privilege-persistence-part-1/
https://www.sentinelone.com/blog/shadow-suid-privilege-persistence-part-2/
