### PR TITLE
Add basic support for Haiku operating system

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
 ## 🔎 About UAC
 
-**UAC (Unix-like Artifacts Collector)** is a powerful and extensible incident response tool designed for forensic investigators, security analysts, and IT professionals. It automates the collection of artifacts from a wide range of Unix-like systems, including AIX, ESXi, FreeBSD, Linux, macOS, NetBSD, NetScaler, OpenBSD and Solaris.
+**UAC (Unix-like Artifacts Collector)** is a powerful and extensible incident response tool designed for forensic investigators, security analysts, and IT professionals. It automates the collection of artifacts from a wide range of Unix-like systems, including AIX, ESXi, FreeBSD, Haiku, Linux, macOS, NetBSD, NetScaler, OpenBSD and Solaris.
 
 Whether you're handling an intrusion, conducting forensic investigations, or performing compliance checks, UAC simplifies and accelerates data collection while minimizing reliance on external support during critical incidents.
 
@@ -78,6 +78,7 @@ UAC runs on any Unix-like system, regardless of the processor architecture. All 
 [![AIX](https://img.shields.io/static/v1?label=&message=AIX&color=brightgreen&style=for-the-badge)](#-supported-operating-systems)
 [![ESXi](https://img.shields.io/static/v1?label=&message=ESXi&color=blue&style=for-the-badge)](#-supported-operating-systems)
 [![FreeBSD](https://img.shields.io/static/v1?label=&message=FreeBSD&color=red&style=for-the-badge)](#-supported-operating-systems)
+[![Haiku](https://img.shields.io/static/v1?label=&message=Haiku&color=white&style=for-the-badge)](#-supported-operating-systems)
 [![Linux](https://img.shields.io/static/v1?label=&message=Linux&color=lightgray&style=for-the-badge)](#-supported-operating-systems)
 [![macOS](https://img.shields.io/static/v1?label=&message=macOS&color=blueviolet&style=for-the-badge)](#-supported-operating-systems)
 [![NetBSD](https://img.shields.io/static/v1?label=&message=NetBSD&color=orange&style=for-the-badge)](#-supported-operating-systems)

--- a/artifacts/files/logs/var_log.yaml
+++ b/artifacts/files/logs/var_log.yaml
@@ -14,3 +14,10 @@ artifacts:
     path: /private/var/log
     file_type: [f, l]
     max_file_size: 1073741824 # 1GB
+  -
+    description: Collect /boot/system/var/log logs.
+    supported_os: [haiku]
+    collector: file
+    path: /boot/system/var/log
+    file_type: [f, l]
+    max_file_size: 1073741824 # 1GB

--- a/artifacts/files/shell/history.yaml
+++ b/artifacts/files/shell/history.yaml
@@ -8,3 +8,9 @@ artifacts:
     # lesshst: less command history file
     name_pattern: [".*_history", ".*history", ".cosh_history", ".dash_history", ".esh_history", ".lesshst", ".nash_history", ".sash_history", ".scsh_history", ".xonsh_history", ".zhistory", "*.historynew", "fish_history"]
     max_depth: 4
+  -
+    description: Collect shell history file for haiku user.
+    supported_os: [haiku]
+    # haiku gets its own definition for the bash history file because the directory /boot/home/config is a special file system that uac is not descending through by default
+    collector: file
+    path: /boot/home/config/settings/bash_history

--- a/artifacts/files/system/etc.yaml
+++ b/artifacts/files/system/etc.yaml
@@ -20,6 +20,13 @@ artifacts:
     path: /private/etc
     exclude_name_pattern: ["shadow", "shadow-"]
     ignore_date_range: true
+  -
+    description: Collect system configuration files.
+    supported_os: [haiku]
+    collector: file
+    path: /boot/system/settings
+    exclude_name_pattern: ["shadow", "shadow-"]
+    ignore_date_range: true
 
 # References:
 # https://www.elastic.co/security-labs/primer-on-persistence-mechanisms

--- a/artifacts/files/system/haiku_launch.yaml
+++ b/artifacts/files/system/haiku_launch.yaml
@@ -1,0 +1,26 @@
+version: 1.0
+artifacts:
+  -
+    description: Collect Daemons configured to start after boot.
+    supported_os: [haiku]
+    collector: file
+    path: /boot/system/data/launch
+    ignore_date_range: true
+  -
+    description: Collect Daemons configured to start after user logon.
+    supported_os: [haiku]
+    collector: file
+    path: /boot/home/config/data/launch
+    ignore_date_range: true
+  -
+    description: Collect UserBootScript.
+    supported_os: [haiku]
+    collector: file
+    path: /boot/home/config/settings/boot/UserBootscript
+    ignore_date_range: true
+  -
+    description: Collect directory referenced in default UserBootScript.
+    supported_os: [haiku]
+    collector: file
+    path: /boot/home/config/settings/boot/launch
+    ignore_date_range: true

--- a/artifacts/files/system/haiku_rostersettings.yaml
+++ b/artifacts/files/system/haiku_rostersettings.yaml
@@ -1,0 +1,10 @@
+version: 1.0
+artifacts:
+  -
+    description: Collect Haiku recently accessed files, folders and applications.
+    supported_os: [haiku]
+    collector: file
+    path: /%user_home%
+    name_pattern: ["RosterSettings"]
+    ignore_date_range: true
+    exclude_nologin_users: true

--- a/artifacts/files/system/tmp.yaml
+++ b/artifacts/files/system/tmp.yaml
@@ -1,4 +1,4 @@
-version: 4.1
+version: 4.2
 artifacts:
   -
     description: Collect system temporary files.
@@ -12,5 +12,12 @@ artifacts:
     supported_os: [macos]
     collector: file
     path: /private/tmp
+    file_type: [f, l]
+    max_file_size: 10485760 # 10MB
+  -
+    description: Collect system temporary files.
+    supported_os: [haiku]
+    collector: file
+    path: /boot/system/cache/tmp
     file_type: [f, l]
     max_file_size: 10485760 # 10MB

--- a/artifacts/live_response/hardware/driveinfo.yaml
+++ b/artifacts/live_response/hardware/driveinfo.yaml
@@ -1,0 +1,10 @@
+version: 1.0
+output_directory: /live_response/hardware
+artifacts:
+  -
+    description: Display information about disk devices.
+    supported_os: [haiku]
+    collector: command
+    foreach: find /dev/disk/ -not -type d
+    command: echo "collecting driveinfo for %line%" && driveinfo %line% && echo '---'
+    output_file: driveinfo_dev_disks.txt

--- a/artifacts/live_response/hardware/listdev.yaml
+++ b/artifacts/live_response/hardware/listdev.yaml
@@ -1,0 +1,15 @@
+version: 1.0
+output_directory: /live_response/hardware
+artifacts:
+  -
+    description: Display hardware devices.
+    supported_os: [haiku]
+    collector: command
+    command: listdev
+    output_file: listdev.txt
+  -
+    description: Display tree structure for hardware devices.
+    supported_os: [haiku]
+    collector: command
+    command: listdev -d
+    output_file: listdev_-d.txt

--- a/artifacts/live_response/hardware/listusb.yaml
+++ b/artifacts/live_response/hardware/listusb.yaml
@@ -1,0 +1,15 @@
+version: 1.0
+output_directory: /live_response/hardware
+artifacts:
+  -
+    description: Display information about USB devices.
+    supported_os: [haiku]
+    collector: command
+    command: listusb
+    output_file: listusb.txt
+  -
+    description: Display detailed information about USB devices.
+    supported_os: [haiku]
+    collector: command
+    command: listusb -v
+    output_file: listusb_-v.txt

--- a/artifacts/live_response/hardware/sysinfo.yaml
+++ b/artifacts/live_response/hardware/sysinfo.yaml
@@ -1,0 +1,9 @@
+version: 1.0
+output_directory: /live_response/hardware
+artifacts:
+  -
+    description: Display a selection of hardware and kernel information.
+    supported_os: [haiku]
+    collector: command
+    command: sysinfo
+    output_file: sysinfo.txt

--- a/artifacts/live_response/network/arp.yaml
+++ b/artifacts/live_response/network/arp.yaml
@@ -4,7 +4,7 @@ output_directory: /live_response/network
 artifacts:
   -
     description: Collect the kernel's IPv4 network neighbour cache.
-    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd, solaris]
+    supported_os: [aix, freebsd, haiku, linux, macos, netbsd, netscaler, openbsd, solaris]
     collector: command
     command: arp -a
     output_file: arp_-a.txt

--- a/artifacts/live_response/network/ifconfig.yaml
+++ b/artifacts/live_response/network/ifconfig.yaml
@@ -4,7 +4,7 @@ output_directory: /live_response/network
 artifacts:
   -
     description: Collect information about all interfaces which are currently available, even if down.
-    supported_os: [aix, freebsd, linux, openbsd, netbsd, netscaler, openbsd, solaris]
+    supported_os: [aix, freebsd, haiku, linux, openbsd, netbsd, netscaler, openbsd, solaris]
     collector: command
     command: ifconfig -a
     output_file: ifconfig_-a.txt

--- a/artifacts/live_response/network/netstat.yaml
+++ b/artifacts/live_response/network/netstat.yaml
@@ -62,3 +62,15 @@ artifacts:
     collector: command
     command: netstat -lpeanut
     output_file: netstat_-lpeanut.txt
+  -
+    description: Collect both listening and non-listening (for TCP this means established connections) sockets.
+    supported_os: [haiku]
+    collector: command
+    command: netstat
+    output_file: netstat.txt
+  -
+    description: Collect both listening and non-listening (for TCP this means established connections) sockets with numerical addresses instead of trying to determine symbolic host, port or user names.
+    supported_os: [haiku]
+    collector: command
+    command: netstat -n
+    output_file: netstat_-n.txt

--- a/artifacts/live_response/network/route.yaml
+++ b/artifacts/live_response/network/route.yaml
@@ -1,0 +1,9 @@
+version: 1.0
+output_directory: /live_response/network
+artifacts:
+  -
+    description: Collect routing tables.
+    supported_os: [haiku]
+    collector: command
+    command: route
+    output_file: route.txt

--- a/artifacts/live_response/packages/pkgman.yaml
+++ b/artifacts/live_response/packages/pkgman.yaml
@@ -1,0 +1,15 @@
+version: 1.0
+output_directory: /live_response/packages
+artifacts:
+  -
+    description: Display installed packages.
+    supported_os: [haiku]
+    collector: command
+    command: pkgman search -a -i
+    output_file: pkgman_search_-a_-i.txt
+  -
+    description: Display installed packages with details.
+    supported_os: [haiku]
+    collector: command
+    command: pkgman search -a -i -D
+    output_file: pkgman_search_-a_-i_-D.txt

--- a/artifacts/live_response/process/fdinfo.yaml
+++ b/artifacts/live_response/process/fdinfo.yaml
@@ -1,0 +1,9 @@
+version: 1.0
+output_directory: /live_response/process
+artifacts:
+  -
+    description: Collect information on used file descriptors.
+    supported_os: [haiku]
+    collector: command
+    command: fdinfo
+    output_file: fdinfo.txt

--- a/artifacts/live_response/process/ps.yaml
+++ b/artifacts/live_response/process/ps.yaml
@@ -1,4 +1,4 @@
-version: 4.0
+version: 4.1
 output_directory: /live_response/process
 artifacts:
   -
@@ -95,3 +95,9 @@ artifacts:
     collector: command
     command: ps -P -T -c -g -s -t -J
     output_file: ps_-P_-T_-c_-g_-s_-t_-J.txt
+  -
+    description: Report a snapshot of the current processes including threads and semaphores.
+    supported_os: [haiku]
+    collector: command
+    command: ps -as
+    output_file: ps_-as.txt

--- a/artifacts/live_response/storage/df.yaml
+++ b/artifacts/live_response/storage/df.yaml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 2.1
 condition: command_exists "df"
 output_directory: /live_response/storage
 artifacts:
@@ -20,3 +20,9 @@ artifacts:
     collector: command
     command: df -n
     output_file: df_-n.txt
+  -
+    description: Report file system disk space usage, including those not visible from Tracker.
+    supported_os: [haiku]
+    collector: command
+    command: df -a
+    output_file: df_-a.txt

--- a/artifacts/live_response/system/launch_roster.yaml
+++ b/artifacts/live_response/system/launch_roster.yaml
@@ -1,0 +1,16 @@
+version: 1.0
+output_directory: /live_response/system
+artifacts:
+  -
+    description: Display information on services managed by launch_daemon.
+    supported_os: [haiku]
+    collector: command
+    command: launch_roster list
+    output_file: launch_roster_list.txt
+  -
+    description: Display information on services managed by launch_daemon.
+    supported_os: [haiku]
+    collector: command
+    command: launch_roster list-targets
+    output_file: launch_roster_list-targets.txt
+  

--- a/artifacts/live_response/system/vmstat.yaml
+++ b/artifacts/live_response/system/vmstat.yaml
@@ -1,10 +1,10 @@
-version: 2.0
+version: 2.1
 condition: command_exists "vmstat"
 output_directory: /live_response/system
 artifacts:
   -
     description: Display virtual memory statistics.
-    supported_os: [aix, freebsd, linux, netbsd, netscaler, openbsd, solaris]
+    supported_os: [aix, freebsd, haiku, linux, netbsd, netscaler, openbsd, solaris]
     collector: command
     command: vmstat
     output_file: vmstat.txt

--- a/lib/get_mount_point_by_file_system.sh
+++ b/lib/get_mount_point_by_file_system.sh
@@ -100,6 +100,24 @@ _get_mount_point_by_file_system()
           }' 2>/dev/null \
         | sed -e 's:|$::' 2>/dev/null
       ;;
+    "haiku")
+      df -a \
+        | awk -v __gm_file_systems="${__gm_file_systems}" \
+          'BEGIN {
+            gsub(/[ ]+/, "", __gm_file_systems);
+            gsub("\"", "", __gm_file_systems);
+            split(__gm_file_systems, __gm_file_system_array, "|");
+            for (i in __gm_file_system_array) {
+              __gm_file_system_dict[__gm_file_system_array[i]]="";
+            }
+          }
+          {
+            if ($1 in __gm_file_system_dict) {
+              printf "%s|", $NF;
+            }
+          }' \
+        | sed -e 's:|$::' 2>/dev/null
+      ;;
   esac
 
 }

--- a/lib/get_operating_system.sh
+++ b/lib/get_operating_system.sh
@@ -40,6 +40,9 @@ _get_operating_system()
     "VMkernel")
       echo "esxi"
       ;;
+    "Haiku")
+      echo "haiku"
+      ;;
     *)
       echo "${__go_kernel_name}"
       ;;

--- a/lib/get_system_arch.sh
+++ b/lib/get_system_arch.sh
@@ -14,7 +14,7 @@ _get_system_arch()
     "aix"|"solaris")
       uname -p
       ;;
-    "esxi"|"freebsd"|"linux"|"macos"|"netbsd"|"netscaler"|"openbsd")
+    "esxi"|"freebsd"|"haiku"|"linux"|"macos"|"netbsd"|"netscaler"|"openbsd")
       uname -m
       ;;
   esac

--- a/lib/list_artifacts.sh
+++ b/lib/list_artifacts.sh
@@ -19,7 +19,7 @@ _list_artifacts()
   fi
 
   case "${__la_os}" in
-    all|aix|esxi|freebsd|linux|macos|netbsd|netscaler|openbsd|solaris)
+    all|aix|esxi|freebsd|haiku|linux|macos|netbsd|netscaler|openbsd|solaris)
       ;;
     *)
       _error_msg "Unsupported operating system: '${__la_os}'"

--- a/lib/tar_data.sh
+++ b/lib/tar_data.sh
@@ -25,7 +25,7 @@ _tar_data()
     "freebsd"|"netbsd"|"netscaler"|"openbsd")
       __td_tar_command="tar -I \"${__td_from_file}\" -cf \"${__td_destination_file}\""
       ;;
-    "esxi"|"linux")
+    "esxi"|"haiku"|"linux")
       if ${__UAC_TOOL_TAR_NO_FROM_FILE_SUPPORT}; then
         __tg_tar_command="tar -cf \"${__td_destination_file}\" *"
       fi

--- a/lib/tar_gz_data.sh
+++ b/lib/tar_gz_data.sh
@@ -25,7 +25,7 @@ _tar_gz_data()
     "freebsd"|"netbsd"|"netscaler"|"openbsd")
       __tg_tar_command="tar -I \"${__tg_from_file}\" -cf - | gzip >\"${__tg_destination_file}\""
       ;;
-    "esxi"|"linux")
+    "esxi"|"haiku"|"linux")
       if ${__UAC_TOOL_TAR_NO_FROM_FILE_SUPPORT}; then
         __tg_tar_command="tar -cf - * | gzip >\"${__tg_destination_file}\""
       fi

--- a/lib/usage.sh
+++ b/lib/usage.sh
@@ -58,8 +58,8 @@ Collection Arguments:
                     Specify the mount point (default: /).
   -s, --operating-system OPERATING_SYSTEM
                     Specify the operating system.
-                    Options: aix, esxi, freebsd, linux, macos, netbsd
-                      netscaler, openbsd, solaris
+                    Options: aix, esxi, freebsd, haiku, linux, macos
+                      netbsd, netscaler, openbsd, solaris
   -H, --hash-collected
                     Hash all collected files.
   -u, --run-as-non-root

--- a/lib/validate_artifact.sh
+++ b/lib/validate_artifact.sh
@@ -383,7 +383,7 @@ _validate_artifact()
               _error_msg "Missing field value: 'supported_os' must not be empty."
               return 1
             fi
-            __va_valid_values="all|aix|esxi|freebsd|linux|macos|netbsd|netscaler|openbsd|solaris"
+            __va_valid_values="all|aix|esxi|freebsd|haiku|linux|macos|netbsd|netscaler|openbsd|solaris"
             for __va_item in `echo "${__va_value}" | sed -e 's:|: :g'`; do
               if _is_in_list "${__va_item}" "${__va_valid_values}"; then
                 true

--- a/uac
+++ b/uac
@@ -129,7 +129,7 @@ if [ -z "${__UAC_OPERATING_SYSTEM}" ]; then
 fi
 
 # check if operating system is supported
-if _is_in_list "${__UAC_OPERATING_SYSTEM}" "aix|esxi|freebsd|linux|macos|netbsd|netscaler|openbsd|solaris"; then
+if _is_in_list "${__UAC_OPERATING_SYSTEM}" "aix|esxi|freebsd|haiku|linux|macos|netbsd|netscaler|openbsd|solaris"; then
   # get system arch
   __UAC_SYSTEM_ARCH=`_get_system_arch "${__UAC_OPERATING_SYSTEM}"`
 else


### PR DESCRIPTION
Hi,

out of interest for rare operating systems and as a small personal project, I added support for another unix-like operating system: https://www.haiku-os.org/
Haiku itself seems to be a niche in a niche - I don't have prior experience with using it.

Regarding artifacts for the operating system, I went through the available documentation on userland binaries (man pages and the official online documentation) and explored around the file system.
I think I managed a good coverage of useful live response information on a base install as well as a decent coverage of relevant files.

I've attached a collection with the changed version of UAC, as well as a collection with the UAC version 3.2.0

I hope this contribution is helpful :)

Kind Regards

Attachments:
[uac-shredder-haiku-20251201214304.tar.gz](https://github.com/user-attachments/files/23866468/uac-shredder-haiku-20251201214304.tar.gz)
[uac-shredder-linux-20251124185659.tar.gz](https://github.com/user-attachments/files/23866470/uac-shredder-linux-20251124185659.tar.gz)
