### PR TITLE
artif: new artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ All notable changes to this project will be documented in this file.
 
 - `live_response/network/netstat.yaml`: Updated to include `netstat -Aan` [aix].
 - `live_response/network/rmsock.yaml`: Identify process ownership for TCP network connections. Used to associate PIDs with network activity on AIX systems where lsof is unavailable [aix].
+- `live_response/process/fstat.yaml`: Updated to include `fstat -n` [freebsd, netbsd, netscaler, openbsd].
+- `live_response/process/ps.yaml`:
+  - Updated to include `ps -eo user,pid,ppid,pcpu,pmem,tty,stat,lstart,args` [freebsd, linux, macos, netbsd, netscaler, openbsd].
+  - Updated to include `ps -eo user,pid,ppid,pcpu,pmem,tty,stat,etime,args` [aix, freebsd, linux, macos, netbsd, netscaler, openbsd].
+  - Updated to include `ps -eo user,pid,ppid,pcpu,pmem,tty,s,etime,args` [solaris].
 
 ### Fixed
 

--- a/artifacts/live_response/process/fstat.yaml
+++ b/artifacts/live_response/process/fstat.yaml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 2.1
 condition: command_exists "fstat"
 output_directory: /live_response/process
 artifacts:
@@ -8,3 +8,9 @@ artifacts:
     collector: command
     command: fstat
     output_file: fstat.txt
+  -
+    description: Collect status of open files.
+    supported_os: [freebsd, netbsd, netscaler, openbsd]
+    collector: command
+    command: fstat -n
+    output_file: fstat_-n.txt

--- a/artifacts/live_response/process/ps.yaml
+++ b/artifacts/live_response/process/ps.yaml
@@ -1,4 +1,4 @@
-version: 4.1
+version: 5.0
 output_directory: /live_response/process
 artifacts:
   -
@@ -8,6 +8,24 @@ artifacts:
     command: ps
     output_file: ps.txt
   -
+    description: Report a snapshot of the current processes including time the command started.
+    supported_os: [freebsd, linux, macos, netbsd, netscaler, openbsd]
+    collector: command
+    command: ps -eo user,pid,ppid,pcpu,pmem,tty,stat,lstart,args
+    output_file: ps_-eo_user_pid_ppid_pcpu_pmem_tty_stat_lstart_args.txt
+  -
+    description: Report a snapshot of the current processes including elapsed time since the process was started.
+    supported_os: [aix, freebsd, linux, macos, netbsd, netscaler, openbsd]
+    collector: command
+    command: ps -eo user,pid,ppid,pcpu,pmem,tty,stat,etime,args
+    output_file: ps_-eo_user_pid_ppid_pcpu_pmem_tty_stat_etime_args.txt
+  -
+    description: Report a snapshot of the current processes including elapsed time since the process was started.
+    supported_os: [solaris]
+    collector: command
+    command: ps -eo user,pid,ppid,pcpu,pmem,tty,s,etime,args
+    output_file: ps_-eo_user_pid_ppid_pcpu_pmem_tty_s_etime_args.txt
+  -
     description: Report a snapshot of the current processes.
     supported_os: [aix, freebsd, linux, macos, netbsd, openbsd, solaris]
     collector: command
@@ -15,80 +33,16 @@ artifacts:
     output_file: ps_auxwww.txt
   -
     description: Report a snapshot of the current processes.
-    supported_os: [linux]
-    collector: command
-    command: ps auxwwwf
-    output_file: ps_auxwwwf.txt
-  -
-    description: Report a snapshot of the current processes.
-    supported_os: [aix, freebsd, linux, macos, netscaler, solaris]
-    collector: command
-    command: ps -deaf
-    output_file: ps_-deaf.txt
-  -
-    description: Report a snapshot of the current processes.
     supported_os: [aix, freebsd, linux, macos, netscaler, solaris]
     collector: command
     command: ps -ef
     output_file: ps_-ef.txt
   -
-    description: Report a snapshot of the current processes.
-    supported_os: [aix, freebsd, linux, macos, netscaler, solaris]
-    collector: command
-    command: ps -efl
-    output_file: ps_-efl.txt
-  -
-    description: Collect system date before reporting a snapshot of the current processes including elapsed time since the process was started.
-    supported_os: [aix, solaris]
-    collector: command
-    condition: ps -eo pid,user,etime,args
-    command: date
-    output_file: date_before_ps_-eo_pid_user_etime_args.txt
-  -
-    description: Report a snapshot of the current processes including elapsed time since the process was started.
-    supported_os: [aix, solaris]
-    collector: command
-    command: ps -eo pid,user,etime,args
-    output_file: ps_-eo_pid_user_etime_args.txt
-  -
-    description: Collect system date before reporting a snapshot of the current processes including elapsed time since the process was started.
-    supported_os: [freebsd, linux, macos, netbsd, netscaler, openbsd]
-    collector: command
-    condition: ps -axo pid,user,etime,args
-    command: date
-    output_file: date_before_ps_-axo_pid_user_etime_args.txt
-  -
-    description: Report a snapshot of the current processes including elapsed time since the process was started.
-    supported_os: [freebsd, linux, macos, netbsd, netscaler, openbsd]
-    collector: command
-    command: ps -axo pid,user,etime,args
-    output_file: ps_-axo_pid_user_etime_args.txt
-  -
-    description: Collet system date before reporting a snapshot of the current processes including time the command started.
-    supported_os: [freebsd, linux, macos, netbsd, netscaler, openbsd]
-    collector: command
-    condition: ps -axo pid,user,lstart,args
-    command: date
-    output_file: date_before_ps_-axo_pid_user_lstart_args.txt
-  -
-    description: Report a snapshot of the current processes including time the command started.
-    supported_os: [freebsd, linux, macos, netbsd, netscaler, openbsd]
-    collector: command
-    command: ps -axo pid,user,lstart,args
-    output_file: ps_-axo_pid_user_lstart_args.txt
-  -
     description: Report a snapshot of the current processes including the control groups to which the process belongs.
     supported_os: [linux]
     collector: command
-    command: ps -axo pid,user,cgroup
-    output_file: ps_-axo_pid_user_cgroup.txt
-  -
-    description: Collect system date before reporting a snapshot of the current processes including used time, verbose, session ID and process group, state and type.
-    supported_os: [esxi]
-    collector: command
-    condition: ps -P -T -c -g -s -t -J
-    command: date
-    output_file: date_before_ps_-P_-T_-c_-g_-s_-t_-J.txt
+    command: ps -eo user,pid,ppid,cgroup
+    output_file: ps_-eo_user_pid_ppid_cgroup.txt
   -
     description: Report a snapshot of the current processes including used time, verbose, session ID and process group, state and type.
     supported_os: [esxi]


### PR DESCRIPTION
- `live_response/process/fstat.yaml`: Updated to include `fstat -n` [freebsd, netbsd, netscaler, openbsd].
- `live_response/process/ps.yaml`:
  - Updated to include `ps -eo user,pid,ppid,pcpu,pmem,tty,stat,lstart,args` [freebsd, linux, macos, netbsd, netscaler, openbsd].
  - Updated to include `ps -eo user,pid,ppid,pcpu,pmem,tty,stat,etime,args` [aix, freebsd, linux, macos, netbsd, netscaler, openbsd].
  - Updated to include `ps -eo user,pid,ppid,pcpu,pmem,tty,s,etime,args` [solaris].