### PR TITLE
Extend Docker artifact support to macOS

### DIFF
--- a/artifacts/live_response/containers/docker.yaml
+++ b/artifacts/live_response/containers/docker.yaml
@@ -4,98 +4,98 @@ output_directory: /live_response/containers
 artifacts:
   -
     description: List all containers.
-    supported_os: [linux]
+    supported_os: [linux, macos]
     collector: command
     command: docker container ls --all --size
     output_file: docker_container_ls_--all_--size.txt
   -
     description: List all images.
-    supported_os: [linux]
+    supported_os: [linux, macos]
     collector: command
     command: docker image ls --all
     output_file: docker_image_ls_--all.txt
   -
     description: Display system-wide information.
-    supported_os: [linux]
+    supported_os: [linux, macos]
     collector: command
     command: docker info
     output_file: docker_info.txt
   -
     description: Show the Docker version information.
-    supported_os: [linux]
+    supported_os: [linux, macos]
     collector: command
     command: docker version
     output_file: docker_version.txt
   -
     description: Display a live stream of one or more container's resource usage statistics.
-    supported_os: [linux]
+    supported_os: [linux, macos]
     collector: command
     command: docker stats --all --no-stream --no-trunc
     output_file: docker_stats_--all_--no-stream_--no-trunc.txt
   -
     description: Fetch the logs of all containers.
-    supported_os: [linux]
+    supported_os: [linux, macos]
     collector: command
     foreach: docker container ps --all | sed 1d | awk '{print $1}'
     command: docker container logs %line%
     output_file: docker_container_logs_%line%.txt
   -
     description: Return low-level information on Docker objects.
-    supported_os: [linux]
+    supported_os: [linux, macos]
     collector: command
     foreach: docker container ps --all | sed 1d | awk '{print $1}'
     command: docker inspect %line%
     output_file: docker_inspect_%line%.txt
   -
     description: Display detailed information on one or more networks.
-    supported_os: [linux]
+    supported_os: [linux, macos]
     collector: command
     foreach: docker container ps --all | sed 1d | awk '{print $1}'
     command: docker network inspect %line%
     output_file: docker_network_inspect_%line%.txt
   -
     description: Display the running processes of all containers.
-    supported_os: [linux]
+    supported_os: [linux, macos]
     collector: command
     foreach: docker container ps --all | sed 1d | awk '{print $1}'
     command: docker top %line%
     output_file: docker_top_%line%.txt
   -
     description: List all networks.
-    supported_os: [linux]
+    supported_os: [linux, macos]
     collector: command
     command: docker network ls
     output_file: docker_network_ls.txt
   -
     description: Displays the raw CNI network configuration for all networks.
-    supported_os: [linux]
+    supported_os: [linux, macos]
     collector: command
     foreach: docker network ls | sed 1d | awk '{print $1}'
     command: docker network inspect %line%
     output_file: docker_network_inspect_%line%.txt
   -
     description: List all volumes.
-    supported_os: [linux]
+    supported_os: [linux, macos]
     collector: command
     command: docker volume ls
     output_file: docker_volume_ls.txt
   -
     description: Display detailed information about all volumes.
-    supported_os: [linux]
+    supported_os: [linux, macos]
     collector: command
     foreach: docker volume ls | sed 1d | awk '{print $2}'
     command: docker volume inspect %line%
     output_file: docker_volume_inspect_%line%.txt
   -
     description: Display changes in the container filesystem since its creation.
-    supported_os: [linux]
+    supported_os: [linux, macos]
     collector: command
     foreach: docker container ps --all | sed 1d | awk '{print $1}'
     command: docker diff %line%
     output_file: docker_diff_%line%.txt
   -
     description: Display a live stream of resource usage statistics.
-    supported_os: [linux]
+    supported_os: [linux, macos]
     collector: command
     foreach: docker container ps --all | sed 1d | awk '{print $1}'
     command: docker stats --no-stream --no-trunc %line%


### PR DESCRIPTION
This pull request expands the operating system support for all Docker-related live response artifact collectors. Previously, these collectors were limited to Linux, but now they also support macOS, enabling Docker artifact collection on both platforms.

