### PR TITLE
add live response macOS UAL command collector

### DIFF
--- a/artifacts/live_response/system/macos_ual.yaml
+++ b/artifacts/live_response/system/macos_ual.yaml
@@ -1,0 +1,12 @@
+version: 1.0
+condition: command_exists "log"
+output_directory: /live_response/system
+artifacts:
+  -
+    description: Collect the macOS Unified Logs into a logarchive.
+    supported_os: [macos]
+    collector: command
+    command: log collect --output macos_unified_logs.logarchive --size %macos_unified_logs_max_size=10240m%
+
+# References:
+# https://ss64.com/mac/log.html


### PR DESCRIPTION
Hello, this PR do the following: 
- Adds a `command` collector artifact that runs `log collect` to capture the macOS Unified Logs as a full `.logarchive` bundle, preserving the metadata (predicates, timesync, etc.) that the existing `files/logs/macos_unified_logs.yaml` file collector loses since it only grabs the raw `.tracev3`/uuidtext files. Similar to the files copy but preserve the travev3 format and associated metadata.
- Capture size is capped via `--size`, defaulting to 10GB (`10240m`), and is overridable at runtime without editing the artifact via `./uac -D macos_unified_logs_max_size=NEW_VALUE`.

It has been tested localy with `sudo ./uac -a live_response/system/macos_ual.yaml`