### PR TITLE
Performing ELF and non ELF checks on binaries and hashing them.

### DIFF
--- a/artifacts/live_response/system/binary_file_types.yaml
+++ b/artifacts/live_response/system/binary_file_types.yaml
@@ -1,0 +1,17 @@
+version: 1.1
+output_directory: /live_response/system
+artifacts:
+  -
+    description: Classify files in common Linux executable directories without following symbolic links.
+    supported_os: [linux]
+    collector: command
+    condition: command_exists "file"
+    command: file -h /bin/* /sbin/* /usr/bin/* /usr/sbin/*
+    output_file: binary_file_types.txt
+  -
+    description: Calculate hashes for files in common Linux executable directories.
+    supported_os: [linux]
+    collector: hash
+    path: /bin/* /sbin/* /usr/bin/* /usr/sbin/*
+    file_type: [f]
+    output_file: binary_file_hashes

--- a/artifacts/live_response/system/binary_file_types.yaml
+++ b/artifacts/live_response/system/binary_file_types.yaml
@@ -8,10 +8,4 @@ artifacts:
     condition: command_exists "file"
     command: file -h /bin/* /sbin/* /usr/bin/* /usr/sbin/*
     output_file: binary_file_types.txt
-  -
-    description: Calculate hashes for files in common Linux executable directories.
-    supported_os: [linux]
-    collector: hash
-    path: /bin/* /sbin/* /usr/bin/* /usr/sbin/*
-    file_type: [f]
-    output_file: binary_file_hashes
+


### PR DESCRIPTION


Added `binary_file_types.yaml` to specify two new artifact collection procedures outputting results to `binary_file_types.txt`. Calculates hashes for files in the same directories, outputting results to `binary_file_hashes`.