### PR TITLE
artif: extend AI coding agent artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to this project will be documented in this file.
 
 ### Artifacts
 
+- `files/applications/ai_tools/claude_code.yaml`: Updated to also collect pre-edit file history, tool results, auto-memory, plans, shell snapshots, hook scripts and IDE lock files [linux, macos]. (by [ecapuano](https://github.com/ecapuano))
+- `files/applications/ai_tools/codex.yaml`: Updated to also collect state, thread-history and log SQLite databases with WAL/SHM sidecars, legacy sqlite databases, AGENTS.md, rules, shell snapshots and installation_id; excludes tmp and cache trees [linux, macos]. (by [ecapuano](https://github.com/ecapuano))
+- `files/applications/ai_tools/copilot.yaml`: Updated to also collect session workspace metadata, plans and checkpoints, the session store database with WAL/SHM sidecars and logs; adds VS Code Copilot Chat conversation transcripts, agent-mode edit snapshots and extension session store [linux, macos]. (by [ecapuano](https://github.com/ecapuano))
+- `files/applications/ai_tools/gemini.yaml`: Updated to also collect custom commands and policies (TOML), GEMINI.md and memory files, and per-project root markers; excludes downloaded binaries, shadow git checkpoints and the browser profile [linux, macos]. (by [ecapuano](https://github.com/ecapuano))
+- `files/applications/ai_tools/opencode.yaml`: Updated to also collect SQLite WAL/SHM sidecars, logs, JSONC config, agent and command definitions and the state directory; excludes node_modules, cloned repos and snapshots [linux, macos]. (by [ecapuano](https://github.com/ecapuano))
 - `files/applications/ai_tools/amp.yaml`: Adds collection of Amp session data, config, and credentials [linux, macos]. (by [walkingawire](https://github.com/walkingawire))
 - `files/applications/ai_tools/claude_code.yaml`: Adds collection of Claude Code session logs, config, and credentials [linux, macos]. (by [walkingawire](https://github.com/walkingawire))
 - `files/applications/ai_tools/claude_desktop.yaml`: Adds collection of Claude Desktop transcripts, config, credentials, storage, skill/plugin definitions, and app logs [macos]. (by [walkingawire](https://github.com/walkingawire))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,20 +8,19 @@ All notable changes to this project will be documented in this file.
 
 ### Artifacts
 
-- `files/applications/ai_tools/claude_code.yaml`: Updated to also collect pre-edit file history, tool results, auto-memory, plans, shell snapshots, hook scripts and IDE lock files [linux, macos]. (by [ecapuano](https://github.com/ecapuano))
-- `files/applications/ai_tools/codex.yaml`: Updated to also collect state, thread-history and log SQLite databases with WAL/SHM sidecars, legacy sqlite databases, AGENTS.md, rules, shell snapshots and installation_id; excludes tmp and cache trees [linux, macos]. (by [ecapuano](https://github.com/ecapuano))
-- `files/applications/ai_tools/copilot.yaml`: Updated to also collect session workspace metadata, plans and checkpoints, the session store database with WAL/SHM sidecars and logs; adds VS Code Copilot Chat conversation transcripts, agent-mode edit snapshots and extension session store [linux, macos]. (by [ecapuano](https://github.com/ecapuano))
-- `files/applications/ai_tools/gemini.yaml`: Updated to also collect custom commands and policies (TOML), GEMINI.md and memory files, and per-project root markers; excludes downloaded binaries, shadow git checkpoints and the browser profile [linux, macos]. (by [ecapuano](https://github.com/ecapuano))
-- `files/applications/ai_tools/opencode.yaml`: Updated to also collect SQLite WAL/SHM sidecars, logs, JSONC config, agent and command definitions and the state directory; excludes node_modules, cloned repos and snapshots [linux, macos]. (by [ecapuano](https://github.com/ecapuano))
 - `files/applications/ai_tools/amp.yaml`: Adds collection of Amp session data, config, and credentials [linux, macos]. (by [walkingawire](https://github.com/walkingawire))
 - `files/applications/ai_tools/claude_code.yaml`: Adds collection of Claude Code session logs, config, and credentials [linux, macos]. (by [walkingawire](https://github.com/walkingawire))
+- `files/applications/ai_tools/claude_code.yaml`: Updated to also collect pre-edit file history, tool results, auto-memory, plans, shell snapshots, hook scripts and IDE lock files [linux, macos]. (by [ecapuano](https://github.com/ecapuano))
 - `files/applications/ai_tools/claude_desktop.yaml`: Adds collection of Claude Desktop transcripts, config, credentials, storage, skill/plugin definitions, and app logs [macos]. (by [walkingawire](https://github.com/walkingawire))
 - `files/applications/ai_tools/codebuff.yaml`: Adds collection of Codebuff chat logs, config, and credentials [linux, macos]. (by [walkingawire](https://github.com/walkingawire))
 - `files/applications/ai_tools/codex.yaml`: Adds collection of OpenAI Codex CLI session logs, config, and auth [linux, macos]. (by [walkingawire](https://github.com/walkingawire))
+- `files/applications/ai_tools/codex.yaml`: Updated to also collect state, thread-history and log SQLite databases with WAL/SHM sidecars, legacy sqlite databases, AGENTS.md, rules, shell snapshots and installation_id; excludes tmp and cache trees [linux, macos]. (by [ecapuano](https://github.com/ecapuano))
 - `files/applications/ai_tools/copilot.yaml`: Adds collection of GitHub Copilot CLI OTEL usage logs, config, and host token/config store [linux, macos]. (by [walkingawire](https://github.com/walkingawire))
+- `files/applications/ai_tools/copilot.yaml`: Updated to also collect session workspace metadata, plans and checkpoints, the session store database with WAL/SHM sidecars and logs; adds VS Code Copilot Chat conversation transcripts, agent-mode edit snapshots and extension session store [linux, macos]. (by [ecapuano](https://github.com/ecapuano))
 - `files/applications/ai_tools/cursor.yaml`: Adds collection of Cursor global data, IDE settings, workspace state, history, and logs [linux, macos]. (by [walkingawire](https://github.com/walkingawire))
 - `files/applications/ai_tools/droid.yaml`: Adds collection of Droid session settings, config, and auth [linux, macos]. (by [walkingawire](https://github.com/walkingawire))
 - `files/applications/ai_tools/gemini.yaml`: Adds collection of Gemini CLI chat logs, config, and OAuth credentials [linux, macos]. (by [walkingawire](https://github.com/walkingawire))
+- `files/applications/ai_tools/gemini.yaml`: Updated to also collect custom commands and policies (TOML), GEMINI.md and memory files, and per-project root markers; excludes downloaded binaries, shadow git checkpoints and the browser profile [linux, macos]. (by [ecapuano](https://github.com/ecapuano))
 - `files/applications/ai_tools/goose.yaml`: Adds collection of Goose session database and config [linux, macos]. (by [walkingawire](https://github.com/walkingawire))
 - `files/applications/ai_tools/hermes.yaml`: Adds collection of Hermes Agent state database and config [linux, macos]. (by [walkingawire](https://github.com/walkingawire))
 - `files/applications/ai_tools/kilo.yaml`: Adds collection of Kilo session database and config [linux, macos].
@@ -29,6 +28,7 @@ All notable changes to this project will be documented in this file.
 - `files/applications/ai_tools/kiro.yaml`: Adds collection of Kiro global config, MCP, agents, steering, prompts, skills, sessions, and CLI/IDE data [linux, macos]. (by [walkingawire](https://github.com/walkingawire))
 - `files/applications/ai_tools/openclaw.yaml`: Adds collection of OpenClaw session logs, config, and auth [linux, macos]. (by [walkingawire](https://github.com/walkingawire))
 - `files/applications/ai_tools/opencode.yaml`: Adds collection of OpenCode session data, config, and credentials [linux, macos]. (by [walkingawire](https://github.com/walkingawire))
+- `files/applications/ai_tools/opencode.yaml`: Updated to also collect SQLite WAL/SHM sidecars, logs, JSONC config, agent and command definitions and the state directory; excludes node_modules, cloned repos and snapshots [linux, macos]. (by [ecapuano](https://github.com/ecapuano))
 - `files/applications/ai_tools/pi_agent.yaml`: Adds collection of pi-agent session logs, config, and credentials [linux, macos]. (by [walkingawire](https://github.com/walkingawire))
 - `files/applications/ai_tools/qwen.yaml`: Adds collection of Qwen Code chat logs, config, and OAuth credentials [linux, macos]. (by [walkingawire](https://github.com/walkingawire))
 - `files/system/macos_privilegedhelpertools.yaml`: Added collection of macOS PrivilegedHelperTools, which may be used for persistence [macos]. (by [F9mc](https://github.com/F9mc))

--- a/artifacts/files/applications/ai_tools/claude_code.yaml
+++ b/artifacts/files/applications/ai_tools/claude_code.yaml
@@ -1,13 +1,25 @@
-version: 1.0
+version: 1.1
 
 artifacts:
   -
-    description: Collect Claude Code session logs, config and credentials.
+    description: Collect Claude Code session transcripts, tool results, auto-memory, plans, pre-edit file history, shell snapshots, hooks, config and credentials.
     supported_os: [linux, macos]
     collector: file
     path: %user_home%/.claude %user_home%/.config/claude
-    name_pattern: ["*.jsonl", "settings.json", "settings.local.json", ".credentials.json", "*.json", "CLAUDE.md", "*.mcp.json", ".mcp.json"]
+    name_pattern: ["*.jsonl", "settings.json", "settings.local.json", ".credentials.json", "*.json", "CLAUDE.md", "*.mcp.json", ".mcp.json", "*.md", "*.txt", "*.sh", "*@v*", "*.lock"]
+    exclude_path_pattern: ["*/plugins/cache/*", "*/plugins/repos/*", "*/plugins/marketplaces/*", "*/node_modules/*", "*/.git/*", "*/.venv/*", "*/site-packages/*", "*/__pycache__/*"]
     file_type: [f]
+    max_file_size: 1g
+    ignore_date_range: true
+    exclude_nologin_users: true
+  -
+    description: Collect Claude Code plugin manifests and plugin hook definitions from installed plugin caches and marketplaces.
+    supported_os: [linux, macos]
+    collector: file
+    path: %user_home%/.claude/plugins
+    name_pattern: ["*.json", "*.jsonl"]
+    file_type: [f]
+    exclude_path_pattern: ["*/node_modules/*", "*/.git/*"]
     max_file_size: 1g
     ignore_date_range: true
     exclude_nologin_users: true

--- a/artifacts/files/applications/ai_tools/codex.yaml
+++ b/artifacts/files/applications/ai_tools/codex.yaml
@@ -1,12 +1,13 @@
-version: 1.0
+version: 1.1
 
 artifacts:
   -
-    description: Collect OpenAI Codex CLI session logs, config and auth.
+    description: Collect OpenAI Codex CLI session rollouts, history, state/thread-history/log SQLite databases, config, instructions, rules, shell snapshots and auth.
     supported_os: [linux, macos]
     collector: file
     path: %user_home%/.codex
-    name_pattern: ["*.jsonl", "config.toml", "auth.json", "version.json", "*.json", "*.log", "*.toml"]
+    name_pattern: ["*.jsonl", "config.toml", "auth.json", "version.json", "*.json", "*.log", "*.toml", "*.sqlite", "*.sqlite-wal", "*.sqlite-shm", "*.db", "*.db-wal", "*.db-shm", "*.md", "*.rules", "*.sh", "installation_id"]
+    exclude_path_pattern: ["*/tmp/*", "*/.tmp/*", "*/cache/*", "*/plugins/*", "*/computer-use/*", "*/node_modules/*", "*/.git/*"]
     file_type: [f]
     max_file_size: 1g
     ignore_date_range: true

--- a/artifacts/files/applications/ai_tools/copilot.yaml
+++ b/artifacts/files/applications/ai_tools/copilot.yaml
@@ -1,13 +1,14 @@
-version: 1.0
+version: 1.1
 
 artifacts:
   -
-    description: Collect GitHub Copilot CLI OTEL usage logs and config.
+    description: Collect GitHub Copilot CLI session state (events, workspace metadata, plans, checkpoints), session store database, logs and config.
     supported_os: [linux, macos]
     collector: file
     path: %user_home%/.copilot
-    name_pattern: ["*.jsonl", "*.json"]
+    name_pattern: ["*.jsonl", "*.json", "*.yaml", "*.md", "*.db", "*.db-wal", "*.db-shm", "*.log"]
     file_type: [f]
+    exclude_path_pattern: ["*/pkg/*"]
     max_file_size: 1g
     ignore_date_range: true
     exclude_nologin_users: true
@@ -18,5 +19,45 @@ artifacts:
     path: %user_home%/.config/github-copilot
     name_pattern: ["*.json", "hosts.json", "apps.json", "versions.json"]
     file_type: [f]
+    ignore_date_range: true
+    exclude_nologin_users: true
+  -
+    description: Collect GitHub Copilot Chat conversation transcripts and agent-mode edit snapshots stored per workspace by VS Code (macOS).
+    supported_os: [macos]
+    collector: file
+    path: %user_home%/Library/"Application Support"/Code/User/workspaceStorage
+    path_pattern: ["*/chatSessions/*", "*/chatEditingSessions/*"]
+    file_type: [f]
+    max_file_size: 1g
+    ignore_date_range: true
+    exclude_nologin_users: true
+  -
+    description: Collect GitHub Copilot Chat conversation transcripts and agent-mode edit snapshots stored per workspace by VS Code (Linux).
+    supported_os: [linux]
+    collector: file
+    path: %user_home%/.config/Code/User/workspaceStorage
+    path_pattern: ["*/chatSessions/*", "*/chatEditingSessions/*"]
+    file_type: [f]
+    max_file_size: 1g
+    ignore_date_range: true
+    exclude_nologin_users: true
+  -
+    description: Collect GitHub Copilot Chat global storage - empty-window and transferred chat sessions and the extension session store database (macOS).
+    supported_os: [macos]
+    collector: file
+    path: %user_home%/Library/"Application Support"/Code/User/globalStorage/emptyWindowChatSessions %user_home%/Library/"Application Support"/Code/User/globalStorage/transferredChatSessions %user_home%/Library/"Application Support"/Code/User/globalStorage/github.copilot-chat
+    name_pattern: ["*.json", "*.jsonl", "*.db", "*.db-wal", "*.db-shm"]
+    file_type: [f]
+    max_file_size: 1g
+    ignore_date_range: true
+    exclude_nologin_users: true
+  -
+    description: Collect GitHub Copilot Chat global storage - empty-window and transferred chat sessions and the extension session store database (Linux).
+    supported_os: [linux]
+    collector: file
+    path: %user_home%/.config/Code/User/globalStorage/emptyWindowChatSessions %user_home%/.config/Code/User/globalStorage/transferredChatSessions %user_home%/.config/Code/User/globalStorage/github.copilot-chat
+    name_pattern: ["*.json", "*.jsonl", "*.db", "*.db-wal", "*.db-shm"]
+    file_type: [f]
+    max_file_size: 1g
     ignore_date_range: true
     exclude_nologin_users: true

--- a/artifacts/files/applications/ai_tools/gemini.yaml
+++ b/artifacts/files/applications/ai_tools/gemini.yaml
@@ -1,12 +1,13 @@
-version: 1.0
+version: 1.1
 
 artifacts:
   -
-    description: Collect Gemini CLI chat logs, config and OAuth credentials.
+    description: Collect Gemini CLI chat logs, prompt history, checkpoints, custom commands, policies, project registry, config and OAuth credentials.
     supported_os: [linux, macos]
     collector: file
     path: %user_home%/.gemini
-    name_pattern: ["*.jsonl", "*.json", "settings.json", "oauth_creds.json", "google_accounts.json", "installation_id"]
+    name_pattern: ["*.jsonl", "*.json", "settings.json", "oauth_creds.json", "google_accounts.json", "installation_id", "*.toml", "*.md", ".project_root"]
+    exclude_path_pattern: ["*/tmp/bin/*", "*/history/*", "*/cli-browser-profile/*"]
     file_type: [f]
     max_file_size: 1g
     ignore_date_range: true

--- a/artifacts/files/applications/ai_tools/opencode.yaml
+++ b/artifacts/files/applications/ai_tools/opencode.yaml
@@ -1,13 +1,14 @@
-version: 1.0
+version: 1.1
 
 artifacts:
   -
-    description: Collect OpenCode session data, config and credentials.
+    description: Collect OpenCode session database (with WAL/SHM sidecars), logs, state, config, agents, commands and credentials.
     supported_os: [linux, macos]
     collector: file
-    path: %user_home%/.local/share/opencode %user_home%/.config/opencode
-    name_pattern: ["*.jsonl", "*.json", "*.db", "*.sqlite", "auth*", "*.toml", "*.yaml"]
+    path: %user_home%/.local/share/opencode %user_home%/.config/opencode %user_home%/.local/state/opencode
+    name_pattern: ["*.jsonl", "*.json", "*.jsonc", "*.db", "*.db-wal", "*.db-shm", "*.sqlite", "auth*", "*.toml", "*.yaml", "*.log", "*.md"]
     file_type: [f]
+    exclude_path_pattern: ["*/node_modules/*", "*/repos/*", "*/snapshot/*"]
     max_file_size: 1g
     ignore_date_range: true
     exclude_nologin_users: true


### PR DESCRIPTION
## Summary

Follow-up to #460. Running the current `ai_tools` artifacts (`ai_agents` before the rename) against live installs on macOS showed the name patterns miss a good chunk of the evidence these tools actually write. This widens five of them and adds VS Code Copilot Chat storage, which wasn't covered anywhere.

### What was being missed

- **claude_code**: `file-history/` pre-edit copies of every file the agent changed (no extension, named `<hash>@v<n>`), `tool-results/*.txt`, auto-memory and plan `*.md`, hook and shell-snapshot `*.sh`
- **codex**: the `state_*.sqlite`, `thread_history_*.sqlite` and `logs_*.sqlite` databases (thread history moved into SQLite), `AGENTS.md`, `rules/*.rules`, `installation_id`
- **copilot**: `session-state/<id>/workspace.yaml` (cwd, repo, branch), `plan.md`, `checkpoints/index.md`, `session-store.db`, `logs/*.log`. Also corrected the description; that folder holds session state, not OTEL logs
- **gemini**: `commands/*.toml`, `policies/*.toml`, `GEMINI.md`, `tmp/<project>/.project_root`
- **opencode**: `opencode.db-wal` / `-shm` (recent sessions live in the WAL until checkpoint), `log/opencode.log`, `opencode.jsonc`, and the `~/.local/state/opencode` directory

### Also

- New entries in `copilot.yaml` for Copilot Chat in VS Code: per-workspace `chatSessions/` and `chatEditingSessions/` (transcripts plus pre-edit snapshots from agent mode), `emptyWindowChatSessions/`, `transferredChatSessions/`, and the `github.copilot-chat/session-store.db`. macOS and Linux paths.
- `exclude_path_pattern` added so the wider patterns don't sweep in plugin caches, `node_modules`, virtualenvs, Codex `tmp`, or OpenCode snapshot/repo trees. Plugin manifests and `hooks.json` are kept through a targeted entry.
- Versions bumped to 1.1, CHANGELOG updated.

### Testing

`--validate-artifact` passes on all five. Ran `uac -u -a` with both the develop and patched versions against this machine and diffed the archives: every category above went from 0 collected to collected, plugin cache and `node_modules` noise dropped from ~340 files to 0, and nothing relevant was lost. Linux `~/.config/Code/User` and OpenCode/Codex/Copilot layouts were also confirmed on a clean Ubuntu host.
